### PR TITLE
refactor: have pairs read config from factory

### DIFF
--- a/src/UniswapV2Factory.sol
+++ b/src/UniswapV2Factory.sol
@@ -62,17 +62,11 @@ contract UniswapV2Factory is IUniswapV2Factory, Ownable {
         require(getPair[token0][token1][curveId] == address(0), "UniswapV2: PAIR_EXISTS"); // single check is sufficient
 
         bytes memory    bytecode;
-        bytes4          initSig;
-        bytes memory    initData;
         if (curveId == 0) {
             bytecode    = type(UniswapV2Pair).creationCode;
-            initSig     = bytes4(keccak256("initialize(address,address,uint256,uint256)"));
-            initData    = abi.encode(token0, token1, defaultSwapFee, defaultPlatformFee);
         }
         else if (curveId == 1) {
             bytecode    = type(HybridPool).creationCode;
-            initSig     = bytes4(keccak256("initialize(address,address,uint256,uint256,uint256)"));
-            initData    = abi.encode(token0, token1, defaultSwapFee, defaultPlatformFee, defaultAmplificationCoefficient);
         }
         else {
             revert("factory: invalid curveId");
@@ -83,9 +77,11 @@ contract UniswapV2Factory is IUniswapV2Factory, Ownable {
             pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
 
-        pair.call(
-            abi.encodePacked(initSig, initData)
-        );
+        pair.call(abi.encodeWithSignature(
+            "initialize(address,address)",
+            token0,
+            token1
+        ));
 
         getPair[token0][token1][curveId] = pair;
         getPair[token1][token0][curveId] = pair; // populate mapping in the reverse direction

--- a/src/interfaces/IUniswapV2Factory.sol
+++ b/src/interfaces/IUniswapV2Factory.sol
@@ -18,6 +18,8 @@ interface IUniswapV2Factory {
 
     function defaultSwapFee() external view returns (uint);
     function defaultPlatformFee() external view returns (uint);
+    function defaultAmplificationCoefficient() external view returns (uint);
+
     function defaultRecoverer() external view returns (address);
     function defaultPlatformFeeOn() external view returns (bool);
 

--- a/src/interfaces/IUniswapV2Pair.sol
+++ b/src/interfaces/IUniswapV2Pair.sol
@@ -1,5 +1,7 @@
 pragma solidity =0.8.13;
 
+import "src/interfaces/IUniswapV2Factory.sol";
+
 interface IUniswapV2Pair {
     event Mint(address indexed sender, uint amount0, uint amount1);
     event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
@@ -15,7 +17,7 @@ interface IUniswapV2Pair {
 
     // solhint-disable-next-line func-name-mixedcase
     function MINIMUM_LIQUIDITY() external pure returns (uint);
-    function factory() external view returns (address);
+    function factory() external view returns (IUniswapV2Factory);
     function token0() external view returns (address);
     function token1() external view returns (address);
     function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
@@ -36,5 +38,5 @@ interface IUniswapV2Pair {
     function setCustomSwapFee(uint _customSwapFee) external;
     function setCustomPlatformFee(uint _customPlatformFee) external;
 
-    function initialize(address _token0, address _token1, uint _swapFee, uint _platformFee) external;
+    function initialize(address _token0, address _token1) external;
 }


### PR DESCRIPTION
## Motivation

I wanted to simplify the factory and lay the path-way for a more generic factory class (the current implementation is hard-coded to two curves). If we think that the factory should be able to support `N` curves (an open question), then we will need to remove curve specific logic from the factory.

This also reduces branching and, in my opinion, is more readable/easy to follow.

## Solution

The pair reads the config it cares about from the factory, instead of the factory shipping the config to the pair.
