### PR TITLE
idea: not memory-safe for non-returning assembly blocks 

### DIFF
--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -110,9 +110,7 @@ contract StablePair is ReservoirPair {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
-        // SAFETY:
-        // This assembly block is memory safe as it does not return to solidity
-        assembly ("memory-safe") {
+        assembly {
             calldatacopy(0, 0, calldatasize())
             let success := delegatecall(gas(), lTarget, 0, calldatasize(), 0, 0)
 
@@ -131,9 +129,7 @@ contract StablePair is ReservoirPair {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
-        // SAFETY:
-        // This assembly block is memory safe as it does not return to solidity
-        assembly ("memory-safe") {
+        assembly {
             calldatacopy(0, 0, calldatasize())
             let success := delegatecall(gas(), lTarget, 0, calldatasize(), 0, 0)
 


### PR DESCRIPTION
## Motivation

In response to [this comment](https://github.com/vexchange/v3-core/pull/150#pullrequestreview-1261945105) 

## Solution

Across the board, memory safe is cheaper. Gas comparison after the change, red is memory-safe, green is not: 

```diff
1,17c1,17
< AssetManagedPairTest:testAdjustManagement(uint256,uint256) (runs: 256, μ: 311695, ~: 312127)
< AssetManagedPairTest:testAdjustManagement_AdjustAfterLoss(uint256) (runs: 256, μ: 478921, ~: 479170)
< AssetManagedPairTest:testAdjustManagement_DecreaseManagement(uint256,uint256) (runs: 256, μ: 498500, ~: 501591)
< AssetManagedPairTest:testAdjustManagement_GreaterThanUint104() (gas: 121990)
< AssetManagedPairTest:testAdjustManagement_Int256Min() (gas: 122559)
< AssetManagedPairTest:testAdjustManagement_KStillHolds(uint256) (runs: 256, μ: 610381, ~: 610253)
< AssetManagedPairTest:testAdjustManagement_Uint104() (gas: 655903)
< AssetManagedPairTest:testBurn_AfterAlmostTotalLoss() (gas: 617638)
< AssetManagedPairTest:testBurn_AfterLoss(uint256,uint256) (runs: 256, μ: 659645, ~: 662821)
< AssetManagedPairTest:testManagedAmount_GreaterThanUint104() (gas: 323525)
< AssetManagedPairTest:testMint_AfterLoss(uint256,uint256) (runs: 256, μ: 586933, ~: 587746)
< AssetManagedPairTest:testSetManager() (gas: 127672)
< AssetManagedPairTest:testSetManager_CannotMigrateWithManaged(uint256,uint256) (runs: 256, μ: 409446, ~: 409878)
< AssetManagedPairTest:testSwap_AfterLoss(uint256) (runs: 256, μ: 711684, ~: 707561)
< AssetManagedPairTest:testSync(uint256,uint256,uint256,uint256) (runs: 256, μ: 461585, ~: 462295)
< AssetManagedPairTest:testSyncManaged_ConstantProduct(uint256,uint256) (runs: 256, μ: 323052, ~: 323041)
< AssetManagedPairTest:testSyncManaged_Stable(uint256,uint256) (runs: 256, μ: 361905, ~: 363677)
---
> AssetManagedPairTest:testAdjustManagement(uint256,uint256) (runs: 256, μ: 311981, ~: 312451)
> AssetManagedPairTest:testAdjustManagement_AdjustAfterLoss(uint256) (runs: 256, μ: 480458, ~: 480704)
> AssetManagedPairTest:testAdjustManagement_DecreaseManagement(uint256,uint256) (runs: 256, μ: 498979, ~: 502166)
> AssetManagedPairTest:testAdjustManagement_GreaterThanUint104() (gas: 122072)
> AssetManagedPairTest:testAdjustManagement_Int256Min() (gas: 122658)
> AssetManagedPairTest:testAdjustManagement_KStillHolds(uint256) (runs: 256, μ: 610649, ~: 610521)
> AssetManagedPairTest:testAdjustManagement_Uint104() (gas: 656055)
> AssetManagedPairTest:testBurn_AfterAlmostTotalLoss() (gas: 617883)
> AssetManagedPairTest:testBurn_AfterLoss(uint256,uint256) (runs: 256, μ: 660187, ~: 663417)
> AssetManagedPairTest:testManagedAmount_GreaterThanUint104() (gas: 323681)
> AssetManagedPairTest:testMint_AfterLoss(uint256,uint256) (runs: 256, μ: 587139, ~: 588013)
> AssetManagedPairTest:testSetManager() (gas: 127654)
> AssetManagedPairTest:testSetManager_CannotMigrateWithManaged(uint256,uint256) (runs: 256, μ: 409703, ~: 410173)
> AssetManagedPairTest:testSwap_AfterLoss(uint256) (runs: 256, μ: 715330, ~: 711311)
> AssetManagedPairTest:testSync(uint256,uint256,uint256,uint256) (runs: 256, μ: 462797, ~: 463510)
> AssetManagedPairTest:testSyncManaged_ConstantProduct(uint256,uint256) (runs: 256, μ: 323051, ~: 323001)
> AssetManagedPairTest:testSyncManaged_Stable(uint256,uint256) (runs: 256, μ: 362147, ~: 363053)
47,49c47,49
< FlashSwapTest:testSwap_FlashSwap_ExactIn(uint256) (runs: 256, μ: 218471, ~: 223079)
< FlashSwapTest:testSwap_FlashSwap_ExactOut(uint256) (runs: 256, μ: 223676, ~: 223729)
< FlashSwapTest:testSwap_FlashSwap_NoPay(uint256) (runs: 256, μ: 179090, ~: 183734)
---
> FlashSwapTest:testSwap_FlashSwap_ExactIn(uint256) (runs: 256, μ: 219690, ~: 224351)
> FlashSwapTest:testSwap_FlashSwap_ExactOut(uint256) (runs: 256, μ: 224971, ~: 225034)
> FlashSwapTest:testSwap_FlashSwap_NoPay(uint256) (runs: 256, μ: 179723, ~: 184424)
52,53c52,53
< GenericFactoryTest:testAllPairs() (gas: 13343771)
< GenericFactoryTest:testCreatePair_AllCurves(uint256) (runs: 256, μ: 6537165, ~: 4313350)
---
> GenericFactoryTest:testAllPairs() (gas: 13679628)
> GenericFactoryTest:testCreatePair_AllCurves(uint256) (runs: 256, μ: 6773974, ~: 4313353)
56c56
< GenericFactoryTest:testCreatePair_MoreThan18Decimals(uint256) (runs: 256, μ: 254419, ~: 251430)
---
> GenericFactoryTest:testCreatePair_MoreThan18Decimals(uint256) (runs: 256, μ: 254879, ~: 251433)
61c61
< OracleCallerTest:testWhitelistAddress() (gas: 147243)
---
> OracleCallerTest:testWhitelistAddress() (gas: 147351)
63,87c63,87
< OracleWriterTest:testMaxChangeRate_Default() (gas: 67083)
< OracleWriterTest:testObservation_NotOracleCaller(uint256) (runs: 256, μ: 76574, ~: 76414)
< OracleWriterTest:testOracle_CompareLiquidityTwoCurves_Balanced() (gas: 183193)
< OracleWriterTest:testOracle_SamePriceDiffLiq() (gas: 13818348)
< OracleWriterTest:testOracle_SamePriceSameLiq() (gas: 13818297)
< OracleWriterTest:testOracle_SameReservesDiffPrice() (gas: 13818545)
< OracleWriterTest:testSetMaxChangeRate_OnlyFactory() (gas: 89559)
< OracleWriterTest:testSetMaxChangeRate_TooHigh(uint256) (runs: 256, μ: 75958, ~: 75952)
< OracleWriterTest:testSetMaxChangeRate_TooLow() (gas: 68889)
< OracleWriterTest:testUpdateOracleCaller() (gas: 114894)
< OracleWriterTest:testUpdateOracleCaller_NoChange() (gas: 84593)
< OracleWriterTest:testUpdateOracle_WriteOldReservesNotNew() (gas: 276125)
< PairTest:testCustomPlatformFee_OffByDefault() (gas: 73235)
< PairTest:testCustomSwapFee_OffByDefault() (gas: 68070)
< PairTest:testEmitEventOnCreation() (gas: 13341776)
< PairTest:testNonPayable() (gas: 79533)
< PairTest:testRecoverToken() (gas: 200537)
< PairTest:testSetPlatformFeeForPair() (gas: 111832)
< PairTest:testSetPlatformFeeForPair_BreachMaximum(uint256) (runs: 256, μ: 109527, ~: 109528)
< PairTest:testSetPlatformFeeForPair_Reset() (gas: 121500)
< PairTest:testSetSwapFeeForPair() (gas: 112766)
< PairTest:testSetSwapFeeForPair_BreachMaximum(uint256) (runs: 256, μ: 109735, ~: 109742)
< PairTest:testSetSwapFeeForPair_Reset() (gas: 127811)
< PairTest:testSwapFee_UseDefault() (gas: 15772)
< PairTest:testUpdateDefaultFees() (gas: 172293)
---
> OracleWriterTest:testMaxChangeRate_Default() (gas: 67067)
> OracleWriterTest:testObservation_NotOracleCaller(uint256) (runs: 256, μ: 76552, ~: 76392)
> OracleWriterTest:testOracle_CompareLiquidityTwoCurves_Balanced() (gas: 185052)
> OracleWriterTest:testOracle_SamePriceDiffLiq() (gas: 14156412)
> OracleWriterTest:testOracle_SamePriceSameLiq() (gas: 14156361)
> OracleWriterTest:testOracle_SameReservesDiffPrice() (gas: 14156609)
> OracleWriterTest:testSetMaxChangeRate_OnlyFactory() (gas: 89514)
> OracleWriterTest:testSetMaxChangeRate_TooHigh(uint256) (runs: 256, μ: 75943, ~: 75937)
> OracleWriterTest:testSetMaxChangeRate_TooLow() (gas: 68874)
> OracleWriterTest:testUpdateOracleCaller() (gas: 114853)
> OracleWriterTest:testUpdateOracleCaller_NoChange() (gas: 84551)
> OracleWriterTest:testUpdateOracle_WriteOldReservesNotNew() (gas: 278064)
> PairTest:testCustomPlatformFee_OffByDefault() (gas: 73203)
> PairTest:testCustomSwapFee_OffByDefault() (gas: 68054)
> PairTest:testEmitEventOnCreation() (gas: 13677633)
> PairTest:testNonPayable() (gas: 79505)
> PairTest:testRecoverToken() (gas: 200654)
> PairTest:testSetPlatformFeeForPair() (gas: 111812)
> PairTest:testSetPlatformFeeForPair_BreachMaximum(uint256) (runs: 256, μ: 109508, ~: 109509)
> PairTest:testSetPlatformFeeForPair_Reset() (gas: 121504)
> PairTest:testSetSwapFeeForPair() (gas: 112776)
> PairTest:testSetSwapFeeForPair_BreachMaximum(uint256) (runs: 256, μ: 109743, ~: 109756)
> PairTest:testSetSwapFeeForPair_Reset() (gas: 127886)
> PairTest:testSwapFee_UseDefault() (gas: 15756)
> PairTest:testUpdateDefaultFees() (gas: 172348)
91,158c91,158
< ReservoirPairTest:testCheckedTransfer_RevertWhenTransferFail() (gas: 137934)
< ReservoirPairTest:testCheckedTransfer_RevertWhenTransferReverts() (gas: 387624)
< ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Burn() (gas: 705939)
< ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Mint() (gas: 755409)
< ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Sync() (gas: 578920)
< ReservoirPairTest:testSkim(uint256,uint256) (runs: 256, μ: 256575, ~: 256468)
< ReservoirPairTest:testSync() (gas: 170895)
< StablePairTest:testAttackWhileRampingDown_LongInterval() (gas: 196424)
< StablePairTest:testAttackWhileRampingDown_ShortInterval() (gas: 196605)
< StablePairTest:testBurn() (gas: 137196)
< StablePairTest:testBurn_DiffDecimalPlaces(uint256) (runs: 256, μ: 9316918, ~: 9316600)
< StablePairTest:testBurn_LastInvariantUseReserveInsteadOfBalance() (gas: 222804)
< StablePairTest:testBurn_Reenter() (gas: 55055)
< StablePairTest:testBurn_WhenRampingA(uint256) (runs: 256, μ: 378427, ~: 378446)
< StablePairTest:testBurn_Zero() (gas: 74190)
< StablePairTest:testFactoryAmpTooHigh() (gas: 651282)
< StablePairTest:testFactoryAmpTooLow() (gas: 646806)
< StablePairTest:testGetCurrentA() (gas: 31716)
< StablePairTest:testMint() (gas: 109132)
< StablePairTest:testMintFee_DiffPlatformFees(uint256) (runs: 256, μ: 10454670, ~: 10458259)
< StablePairTest:testMintFee_WhenRampingA_PoolBalanced(uint256) (runs: 256, μ: 10609494, ~: 10609546)
< StablePairTest:testMintFee_WhenRampingA_PoolUnbalanced(uint256) (runs: 256, μ: 10099786, ~: 10099393)
< StablePairTest:testMint_NonOptimalProportion() (gas: 141357)
< StablePairTest:testMint_NonOptimalProportion_ThenBurn() (gas: 289570)
< StablePairTest:testMint_OnlyTransferOneToken() (gas: 9098484)
< StablePairTest:testMint_PlatformFeeOff() (gas: 114960)
< StablePairTest:testMint_Reenter() (gas: 54320)
< StablePairTest:testMint_WhenRampingA(uint256) (runs: 256, μ: 397185, ~: 397201)
< StablePairTest:testOracle_ClampedPrice_NoDiffWithinLimit() (gas: 198087)
< StablePairTest:testOracle_CorrectLiquidity() (gas: 243625)
< StablePairTest:testOracle_CorrectPrice() (gas: 292226)
< StablePairTest:testOracle_LiquidityAtMaximum() (gas: 224052)
< StablePairTest:testOracle_NoWriteInSameTimestamp() (gas: 209225)
< StablePairTest:testOracle_OverflowAccLiquidity() (gas: 114050)
< StablePairTest:testOracle_OverflowAccPrice() (gas: 176541)
< StablePairTest:testOracle_SimplePrices() (gas: 322171)
< StablePairTest:testOracle_WrapsAroundAfterFull() (gas: 3852592602)
< StablePairTest:testPlatformFee_Disable() (gas: 433460)
< StablePairTest:testPlatformFee_DisableReenable() (gas: 620926)
< StablePairTest:testRampA() (gas: 31328)
< StablePairTest:testRampA_BreachMaxSpeed() (gas: 23220)
< StablePairTest:testRampA_BreachMaximum() (gas: 19158)
< StablePairTest:testRampA_BreachMinimum() (gas: 18728)
< StablePairTest:testRampA_MaxSpeed() (gas: 26394)
< StablePairTest:testRampA_OnlyFactory() (gas: 8834)
< StablePairTest:testRampA_SetAtMaximum() (gas: 25019)
< StablePairTest:testRampA_SetAtMinimum() (gas: 24571)
< StablePairTest:testRampA_SwappingDuringRampingDown(uint256,uint256,uint256,uint256) (runs: 256, μ: 491416, ~: 505383)
< StablePairTest:testRampA_SwappingDuringRampingUp(uint256,uint256,uint256,uint256) (runs: 256, μ: 492384, ~: 506582)
< StablePairTest:testStopRampA() (gas: 34038)
< StablePairTest:testStopRampA_Early(uint256) (runs: 256, μ: 40489, ~: 40476)
< StablePairTest:testStopRampA_Late(uint256) (runs: 256, μ: 40700, ~: 40713)
< StablePairTest:testStopRampA_OnlyFactory() (gas: 9177)
< StablePairTest:testSwap() (gas: 85738)
< StablePairTest:testSwap_BetterPerformanceThanConstantProduct() (gas: 126609)
< StablePairTest:testSwap_DiffAs(uint256,uint256,uint256) (runs: 256, μ: 9332066, ~: 9333438)
< StablePairTest:testSwap_DiffSwapFees(uint256) (runs: 256, μ: 9336509, ~: 9338763)
< StablePairTest:testSwap_ExactInExceedUint104() (gas: 78199)
< StablePairTest:testSwap_ExactOutExceedReserves() (gas: 41917)
< StablePairTest:testSwap_IncreasingSwapFees(uint256,uint256,uint256) (runs: 256, μ: 297361, ~: 297384)
< StablePairTest:testSwap_MinInt256() (gas: 16449)
< StablePairTest:testSwap_Reenter() (gas: 89940)
< StablePairTest:testSwap_Token0ExactOut(uint256) (runs: 256, μ: 115132, ~: 121572)
< StablePairTest:testSwap_Token1ExactOut(uint256) (runs: 256, μ: 115225, ~: 121665)
< StablePairTest:testSwap_VeryLargeLiquidity(uint256) (runs: 256, μ: 9306230, ~: 9306423)
< StablePairTest:testSwap_VerySmallLiquidity(uint256,uint256,uint256) (runs: 256, μ: 9305896, ~: 9305902)
< StablePairTest:testSwap_ZeroInput() (gas: 15559)
< StablePairTest:testWriteObservations() (gas: 235756)
---
> ReservoirPairTest:testCheckedTransfer_RevertWhenTransferFail() (gas: 138426)
> ReservoirPairTest:testCheckedTransfer_RevertWhenTransferReverts() (gas: 388000)
> ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Burn() (gas: 706370)
> ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Mint() (gas: 755840)
> ReservoirPairTest:testOracleWriteAfterAssetManagerProfit_Sync() (gas: 581514)
> ReservoirPairTest:testSkim(uint256,uint256) (runs: 256, μ: 256571, ~: 256464)
> ReservoirPairTest:testSync() (gas: 171514)
> StablePairTest:testAttackWhileRampingDown_LongInterval() (gas: 200867)
> StablePairTest:testAttackWhileRampingDown_ShortInterval() (gas: 200806)
> StablePairTest:testBurn() (gas: 137138)
> StablePairTest:testBurn_DiffDecimalPlaces(uint256) (runs: 256, μ: 9652697, ~: 9652379)
> StablePairTest:testBurn_LastInvariantUseReserveInsteadOfBalance() (gas: 223860)
> StablePairTest:testBurn_Reenter() (gas: 55039)
> StablePairTest:testBurn_WhenRampingA(uint256) (runs: 256, μ: 378517, ~: 378535)
> StablePairTest:testBurn_Zero() (gas: 74175)
> StablePairTest:testFactoryAmpTooHigh() (gas: 652081)
> StablePairTest:testFactoryAmpTooLow() (gas: 647605)
> StablePairTest:testGetCurrentA() (gas: 31824)
> StablePairTest:testMint() (gas: 109125)
> StablePairTest:testMintFee_DiffPlatformFees(uint256) (runs: 256, μ: 10844536, ~: 10848124)
> StablePairTest:testMintFee_WhenRampingA_PoolBalanced(uint256) (runs: 256, μ: 10997435, ~: 10997486)
> StablePairTest:testMintFee_WhenRampingA_PoolUnbalanced(uint256) (runs: 256, μ: 10462628, ~: 10462235)
> StablePairTest:testMint_NonOptimalProportion() (gas: 141326)
> StablePairTest:testMint_NonOptimalProportion_ThenBurn() (gas: 290643)
> StablePairTest:testMint_OnlyTransferOneToken() (gas: 9434326)
> StablePairTest:testMint_PlatformFeeOff() (gas: 114925)
> StablePairTest:testMint_Reenter() (gas: 54304)
> StablePairTest:testMint_WhenRampingA(uint256) (runs: 256, μ: 397271, ~: 397286)
> StablePairTest:testOracle_ClampedPrice_NoDiffWithinLimit() (gas: 202451)
> StablePairTest:testOracle_CorrectLiquidity() (gas: 245571)
> StablePairTest:testOracle_CorrectPrice() (gas: 299587)
> StablePairTest:testOracle_LiquidityAtMaximum() (gas: 225988)
> StablePairTest:testOracle_NoWriteInSameTimestamp() (gas: 210867)
> StablePairTest:testOracle_OverflowAccLiquidity() (gas: 116205)
> StablePairTest:testOracle_OverflowAccPrice() (gas: 180063)
> StablePairTest:testOracle_SimplePrices() (gas: 330561)
> StablePairTest:testOracle_WrapsAroundAfterFull() (gas: 4032718322)
> StablePairTest:testPlatformFee_Disable() (gas: 438322)
> StablePairTest:testPlatformFee_DisableReenable() (gas: 629968)
> StablePairTest:testRampA() (gas: 31460)
> StablePairTest:testRampA_BreachMaxSpeed() (gas: 23332)
> StablePairTest:testRampA_BreachMaximum() (gas: 19224)
> StablePairTest:testRampA_BreachMinimum() (gas: 18792)
> StablePairTest:testRampA_MaxSpeed() (gas: 26526)
> StablePairTest:testRampA_OnlyFactory() (gas: 8860)
> StablePairTest:testRampA_SetAtMaximum() (gas: 25164)
> StablePairTest:testRampA_SetAtMinimum() (gas: 24719)
> StablePairTest:testRampA_SwappingDuringRampingDown(uint256,uint256,uint256,uint256) (runs: 256, μ: 499414, ~: 513623)
> StablePairTest:testRampA_SwappingDuringRampingUp(uint256,uint256,uint256,uint256) (runs: 256, μ: 500452, ~: 514835)
> StablePairTest:testStopRampA() (gas: 34187)
> StablePairTest:testStopRampA_Early(uint256) (runs: 256, μ: 40614, ~: 40617)
> StablePairTest:testStopRampA_Late(uint256) (runs: 256, μ: 40825, ~: 40836)
> StablePairTest:testStopRampA_OnlyFactory() (gas: 9158)
> StablePairTest:testSwap() (gas: 86862)
> StablePairTest:testSwap_BetterPerformanceThanConstantProduct() (gas: 127733)
> StablePairTest:testSwap_DiffAs(uint256,uint256,uint256) (runs: 256, μ: 9669012, ~: 9670403)
> StablePairTest:testSwap_DiffSwapFees(uint256) (runs: 256, μ: 9673655, ~: 9675907)
> StablePairTest:testSwap_ExactInExceedUint104() (gas: 78614)
> StablePairTest:testSwap_ExactOutExceedReserves() (gas: 42341)
> StablePairTest:testSwap_IncreasingSwapFees(uint256,uint256,uint256) (runs: 256, μ: 300781, ~: 300809)
> StablePairTest:testSwap_MinInt256() (gas: 16572)
> StablePairTest:testSwap_Reenter() (gas: 90622)
> StablePairTest:testSwap_Token0ExactOut(uint256) (runs: 256, μ: 116623, ~: 123126)
> StablePairTest:testSwap_Token1ExactOut(uint256) (runs: 256, μ: 116735, ~: 123238)
> StablePairTest:testSwap_VeryLargeLiquidity(uint256) (runs: 256, μ: 9643192, ~: 9643321)
> StablePairTest:testSwap_VerySmallLiquidity(uint256,uint256,uint256) (runs: 256, μ: 9642603, ~: 9642652)
> StablePairTest:testSwap_ZeroInput() (gas: 15675)
> StablePairTest:testWriteObservations() (gas: 241492)
171,176c171,176
< StablePairGas:testGasBurn() (gas: 95095)
< StablePairGas:testGasMint() (gas: 116347)
< StablePairGas:testGasMint_Initial() (gas: 211217)
< StablePairGas:testGasSwap() (gas: 64603)
< StablePairGas:testGasSwap_UpdateOracle() (gas: 109017)
< StablePairGas:testGasSwap_UpdateOracleClamped() (gas: 104984)
---
> StablePairGas:testGasBurn() (gas: 95074)
> StablePairGas:testGasMint() (gas: 116332)
> StablePairGas:testGasMint_Initial() (gas: 211202)
> StablePairGas:testGasSwap() (gas: 65872)
> StablePairGas:testGasSwap_UpdateOracle() (gas: 111515)
> StablePairGas:testGasSwap_UpdateOracleClamped() (gas: 107506)
180,182c180,182
< StableMathTest:testComputeLiquidityFromAdjustedBalances_ConvergeEvenWithVeryUnbalancedValues(uint256,uint256,uint256) (runs: 256, μ: 14251, ~: 10575)
< StableMathTest:testGetAmountIn(uint256,uint256,uint256) (runs: 256, μ: 20033, ~: 19680)
< StableMathTest:testGetAmountOut(uint256,uint256,uint256) (runs: 256, μ: 24031, ~: 23202)
---
> StableMathTest:testComputeLiquidityFromAdjustedBalances_ConvergeEvenWithVeryUnbalancedValues(uint256,uint256,uint256) (runs: 256, μ: 14344, ~: 10721)
> StableMathTest:testGetAmountIn(uint256,uint256,uint256) (runs: 256, μ: 20012, ~: 19643)
> StableMathTest:testGetAmountOut(uint256,uint256,uint256) (runs: 256, μ: 24000, ~: 23339)
```