### PR TITLE
feat: make `MINT_BURN_LOGIC` fixed address and `StableMintBurn` standalone address 

### DIFF
--- a/src/GenericFactory.sol
+++ b/src/GenericFactory.sol
@@ -185,19 +185,17 @@ contract GenericFactory is IGenericFactory, Owned {
 
     event Deployed(address _address);
 
-    function deploySharedContract(bytes calldata aInitCode, address aToken0, address aToken1)
+    function deploySharedContract(bytes memory aInitCode)
         external
         onlyOwner
         returns (address rContract)
     {
-        bytes memory lInitCode = bytes.concat(aInitCode, abi.encode(aToken0), abi.encode(aToken1));
-
         // SAFETY:
         // Does not write to memory
         assembly ("memory-safe") {
             // sanity checked against OZ implementation:
             // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/3ac4add548178708f5401c26280b952beb244c1e/contracts/utils/Create2.sol#L40
-            rContract := create2(callvalue(), add(lInitCode, 0x20), mload(lInitCode), 0)
+            rContract := create2(callvalue(), add(aInitCode, 0x20), mload(aInitCode), 0)
 
             if iszero(extcodesize(rContract)) { revert(0, 0) }
         }

--- a/src/GenericFactory.sol
+++ b/src/GenericFactory.sol
@@ -185,11 +185,7 @@ contract GenericFactory is IGenericFactory, Owned {
 
     event Deployed(address _address);
 
-    function deploySharedContract(bytes memory aInitCode)
-        external
-        onlyOwner
-        returns (address rContract)
-    {
+    function deploySharedContract(bytes memory aInitCode) external onlyOwner returns (address rContract) {
         // SAFETY:
         // Does not write to memory
         assembly ("memory-safe") {

--- a/src/GenericFactory.sol
+++ b/src/GenericFactory.sol
@@ -92,12 +92,6 @@ contract GenericFactory is IGenericFactory, Owned {
         return lInitCode;
     }
 
-    function addBytecode(bytes calldata aInitCode) external onlyOwner returns (bytes32 rCodeKey) {
-        rCodeKey = keccak256(aInitCode);
-
-        _writeBytecode(rCodeKey, aInitCode);
-    }
-
     /*//////////////////////////////////////////////////////////////////////////
                                     CURVES
     //////////////////////////////////////////////////////////////////////////*/
@@ -189,14 +183,14 @@ contract GenericFactory is IGenericFactory, Owned {
         return Address.functionCallWithValue(aTarget, aCalldata, aValue, "FACTORY: RAW_CALL_REVERTED");
     }
 
-    event Deployed(bytes32 codeId, address _address);
+    event Deployed(address _address);
 
-    function deploySharedContract(bytes32 aCodeKey, address aToken0, address aToken1)
+    function deploySharedContract(bytes calldata aInitCode, address aToken0, address aToken1)
         external
         onlyOwner
         returns (address rContract)
     {
-        bytes memory lInitCode = getBytecode(aCodeKey, aToken0, aToken1);
+        bytes memory lInitCode = bytes.concat(aInitCode, abi.encode(aToken0), abi.encode(aToken1));
 
         // SAFETY:
         // Does not write to memory
@@ -208,6 +202,6 @@ contract GenericFactory is IGenericFactory, Owned {
             if iszero(extcodesize(rContract)) { revert(0, 0) }
         }
 
-        emit Deployed(aCodeKey, rContract);
+        emit Deployed(rContract);
     }
 }

--- a/src/curve/stable/StableMintBurn.sol
+++ b/src/curve/stable/StableMintBurn.sol
@@ -147,9 +147,9 @@ contract StableMintBurn is ReservoirERC20, IAssetManagedPair {
 
         uint32 lBlockTimestamp = uint32(_currentTime());
         uint32 lTimeElapsed;
-    unchecked {
-        lTimeElapsed = lBlockTimestamp - aBlockTimestampLast; // overflow is desired
-    }
+        unchecked {
+            lTimeElapsed = lBlockTimestamp - aBlockTimestampLast; // overflow is desired
+        }
         if (lTimeElapsed > 0 && aReserve0 != 0 && aReserve1 != 0) {
             _updateOracle(aReserve0, aReserve1, lTimeElapsed, aBlockTimestampLast);
         }
@@ -359,29 +359,29 @@ contract StableMintBurn is ReservoirERC20, IAssetManagedPair {
         rTimestamp = aRawTimestamp & 0x7FFFFFFF;
     }
 
-    function _updateOracle(uint256 aReserve0, uint256 aReserve1, uint32 aTimeElapsed, uint32 aTimestampLast)
-        internal
-    {
+    function _updateOracle(uint256 aReserve0, uint256 aReserve1, uint32 aTimeElapsed, uint32 aTimestampLast) internal {
         Observation storage previous = _observations[_slot0.index];
 
         (uint256 currRawPrice, int112 currLogRawPrice) = StableOracleMath.calcLogPrice(
-            _getCurrentAPrecise(), aReserve0 * this.token0PrecisionMultiplier(), aReserve1 * this.token1PrecisionMultiplier()
+            _getCurrentAPrecise(),
+            aReserve0 * this.token0PrecisionMultiplier(),
+            aReserve1 * this.token1PrecisionMultiplier()
         );
         // perf: see if we can avoid using prevClampedPrice and read the two previous oracle observations
         // to figure out the previous clamped price
         (uint256 currClampedPrice, int112 currLogClampedPrice) =
-        _calcClampedPrice(currRawPrice, prevClampedPrice, aTimeElapsed);
+            _calcClampedPrice(currRawPrice, prevClampedPrice, aTimeElapsed);
         int112 currLogLiq = StableOracleMath.calcLogLiq(aReserve0, aReserve1);
         prevClampedPrice = currClampedPrice;
 
-    unchecked {
-        int112 logAccRawPrice = previous.logAccRawPrice + currLogRawPrice * int112(int256(uint256(aTimeElapsed)));
-        int56 logAccClampedPrice =
-        previous.logAccClampedPrice + int56(currLogClampedPrice) * int56(int256(uint256(aTimeElapsed)));
-        int56 logAccLiq = previous.logAccLiquidity + int56(currLogLiq) * int56(int256(uint256(aTimeElapsed)));
-        _slot0.index += 1;
-        _observations[_slot0.index] = Observation(logAccRawPrice, logAccClampedPrice, logAccLiq, aTimestampLast);
-    }
+        unchecked {
+            int112 logAccRawPrice = previous.logAccRawPrice + currLogRawPrice * int112(int256(uint256(aTimeElapsed)));
+            int56 logAccClampedPrice =
+                previous.logAccClampedPrice + int56(currLogClampedPrice) * int56(int256(uint256(aTimeElapsed)));
+            int56 logAccLiq = previous.logAccLiquidity + int56(currLogLiq) * int56(int256(uint256(aTimeElapsed)));
+            _slot0.index += 1;
+            _observations[_slot0.index] = Observation(logAccRawPrice, logAccClampedPrice, logAccLiq, aTimestampLast);
+        }
     }
 
     function _currentTime() internal view returns (uint32) {
@@ -412,7 +412,11 @@ contract StableMintBurn is ReservoirERC20, IAssetManagedPair {
         }
     }
 
-    function adjustManagement(int256 aToken0Change, int256 aToken1Change) external {}
-    function getReserves() public view returns (uint104 rReserve0, uint104 rReserve1, uint32 rBlockTimestampLast, uint16 rIndex) {}
-    function setManager(IAssetManager manager) external {}
+    function adjustManagement(int256 aToken0Change, int256 aToken1Change) external { }
+    function getReserves()
+        public
+        view
+        returns (uint104 rReserve0, uint104 rReserve1, uint32 rBlockTimestampLast, uint16 rIndex)
+    { }
+    function setManager(IAssetManager manager) external { }
 }

--- a/src/curve/stable/StableMintBurn.sol
+++ b/src/curve/stable/StableMintBurn.sol
@@ -3,29 +3,69 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+import { stdMath } from "forge-std/Test.sol";
+import { SafeCast } from "@openzeppelin/utils/math/SafeCast.sol";
+
 import { Bytes32Lib } from "src/libraries/Bytes32.sol";
 import { FactoryStoreLib } from "src/libraries/FactoryStore.sol";
 import { StableMath } from "src/libraries/StableMath.sol";
+import { StableOracleMath } from "src/libraries/StableOracleMath.sol";
+import { LogCompression } from "src/libraries/LogCompression.sol";
 
+import { IAssetManager } from "src/interfaces/IAssetManager.sol";
+import { IAssetManagedPair } from "src/interfaces/IAssetManagedPair.sol";
 import { GenericFactory } from "src/GenericFactory.sol";
-import { StablePair } from "src/curve/stable/StablePair.sol";
+import { ReservoirERC20, ERC20 } from "src/ReservoirERC20.sol";
+import { Slot0, Observation } from "src/ReservoirPair.sol";
+import { StablePair, AmplificationData } from "src/curve/stable/StablePair.sol";
 
-struct AmplificationData {
-    /// @dev initialA is stored with A_PRECISION (i.e. multiplied by 100)
-    uint64 initialA;
-    /// @dev futureA is stored with A_PRECISION (i.e. multiplied by 100)
-    uint64 futureA;
-    /// @dev initialATime is a unix timestamp and will only overflow every 584 billion years
-    uint64 initialATime;
-    /// @dev futureATime is a unix timestamp and will only overflow every 584 billion years
-    uint64 futureATime;
-}
-
-contract StableMintBurn is StablePair {
+contract StableMintBurn is ReservoirERC20 {
     using FactoryStoreLib for GenericFactory;
     using Bytes32Lib for bytes32;
+    using SafeCast for uint256;
 
-    constructor(address aToken0, address aToken1) StablePair(aToken0, aToken1) {}
+    uint256 public constant FEE_ACCURACY = 1_000_000; // 100%
+    bytes4 private constant SELECTOR = bytes4(keccak256("transfer(address,uint256)"));
+    uint256 public constant MINIMUM_LIQUIDITY = 10 ** 3;
+    string internal constant PLATFORM_FEE_TO_NAME = "Shared::platformFeeTo";
+
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1);
+    event Sync(uint104 reserve0, uint104 reserve1);
+    event ProfitReported(ERC20 token, uint256 amount);
+    event LossReported(ERC20 token, uint256 amount);
+
+    GenericFactory public immutable factory = GenericFactory(0x0000000000000000000000000000000000000000);
+    ERC20 public immutable token0 = ERC20(0x0000000000000000000000000000000000000000);
+    ERC20 public immutable token1 = ERC20(0x0000000000000000000000000000000000000000);
+
+    uint128 public immutable token0PrecisionMultiplier = 0;
+    uint128 public immutable token1PrecisionMultiplier = 0;
+
+    // does it make a diff in terms of gas when we make the following private / public?
+    // cuz it does not make a diff in terms of storage layout
+    Slot0 private _slot0;
+
+    uint256 private swapFee;
+    uint256 private customSwapFee;
+    uint256 private platformFee;
+    uint256 private customPlatformFee;
+
+    IAssetManager public assetManager;
+
+    uint104 public token0Managed;
+    uint104 public token1Managed;
+
+    Observation[65_536] internal _observations;
+
+    uint256 public maxChangeRate;
+    uint256 public prevClampedPrice;
+    address public oracleCaller;
+
+    AmplificationData public ampData;
+
+    uint192 private lastInvariant;
+    uint64 private lastInvariantAmp;
 
     /// @dev This fee is charged to cover for `swapFee` when users add unbalanced liquidity.
     function _nonOptimalMintFee(uint256 aAmount0, uint256 aAmount1, uint256 aReserve0, uint256 aReserve1)
@@ -45,7 +85,127 @@ contract StableMintBurn is StablePair {
         require(rToken0Fee <= type(uint104).max && rToken1Fee <= type(uint104).max, "SP: NON_OPTIMAL_FEE_TOO_LARGE");
     }
 
-    function mint(address aTo) external override returns (uint256 rLiquidity) {
+    function _syncManaged(uint256 aReserve0, uint256 aReserve1)
+        internal
+        returns (uint256 rReserve0, uint256 rReserve1)
+    {
+        if (address(assetManager) == address(0)) {
+            return (aReserve0, aReserve1);
+        }
+
+        uint256 lToken0Managed = assetManager.getBalance(IAssetManagedPair(this), this.token0());
+        uint256 lToken1Managed = assetManager.getBalance(IAssetManagedPair(this), this.token1());
+
+        rReserve0 = _handleReport(this.token0(), aReserve0, token0Managed, lToken0Managed);
+        rReserve1 = _handleReport(this.token1(), aReserve1, token1Managed, lToken1Managed);
+
+        token0Managed = lToken0Managed.toUint104();
+        token1Managed = lToken1Managed.toUint104();
+    }
+
+    function _handleReport(ERC20 aToken, uint256 aReserve, uint256 aPrevBalance, uint256 aNewBalance)
+        private
+        returns (uint256 rUpdatedReserve)
+    {
+        if (aNewBalance > aPrevBalance) {
+            // report profit
+            uint256 lProfit = aNewBalance - aPrevBalance;
+
+            emit ProfitReported(aToken, lProfit);
+
+            rUpdatedReserve = aReserve + lProfit;
+        } else if (aNewBalance < aPrevBalance) {
+            // report loss
+            uint256 lLoss = aPrevBalance - aNewBalance;
+
+            emit LossReported(aToken, lLoss);
+
+            rUpdatedReserve = aReserve - lLoss;
+        } else {
+            // Balances are equal, return the original reserve.
+            rUpdatedReserve = aReserve;
+        }
+    }
+
+    function _managerCallback() internal {
+        if (address(assetManager) == address(0)) {
+            return;
+        }
+        assetManager.afterLiquidityEvent();
+    }
+
+    // update reserves and, on the first call per block, price and liq accumulators
+    function _updateAndUnlock(
+        uint256 aBalance0,
+        uint256 aBalance1,
+        uint256 aReserve0,
+        uint256 aReserve1,
+        uint32 aBlockTimestampLast
+    ) internal {
+        require(aBalance0 <= type(uint104).max && aBalance1 <= type(uint104).max, "RP: OVERFLOW");
+        require(aReserve0 <= type(uint104).max && aReserve1 <= type(uint104).max, "RP: OVERFLOW");
+
+        uint32 lBlockTimestamp = uint32(_currentTime());
+        uint32 lTimeElapsed;
+    unchecked {
+        lTimeElapsed = lBlockTimestamp - aBlockTimestampLast; // overflow is desired
+    }
+        if (lTimeElapsed > 0 && aReserve0 != 0 && aReserve1 != 0) {
+            _updateOracle(aReserve0, aReserve1, lTimeElapsed, aBlockTimestampLast);
+        }
+
+        _slot0.reserve0 = uint104(aBalance0);
+        _slot0.reserve1 = uint104(aBalance1);
+        _writeSlot0Timestamp(lBlockTimestamp, false);
+
+        emit Sync(uint104(aBalance0), uint104(aBalance1));
+    }
+
+    function _writeSlot0Timestamp(uint32 aTimestamp, bool aLocked) internal {
+        uint32 lLocked = aLocked ? uint32(1 << 31) : uint32(0);
+        _slot0.packedTimestamp = aTimestamp | lLocked;
+    }
+
+    function _lockAndLoad()
+        internal
+        returns (uint104 rReserve0, uint104 rReserve1, uint32 rBlockTimestampLast, uint16 rIndex)
+    {
+        Slot0 memory lSlot0 = _slot0;
+
+        // Load slot0 values.
+        bool lLock;
+        rReserve0 = lSlot0.reserve0;
+        rReserve1 = lSlot0.reserve1;
+        (rBlockTimestampLast, lLock) = _splitSlot0Timestamp(lSlot0.packedTimestamp);
+        rIndex = lSlot0.index;
+
+        // Acquire reentrancy lock.
+        require(!lLock, "REENTRANCY");
+        _writeSlot0Timestamp(rBlockTimestampLast, true);
+    }
+
+    function _checkedTransfer(ERC20 aToken, address aDestination, uint256 aAmount, uint256 aReserve0, uint256 aReserve1)
+        internal
+    {
+        if (!_safeTransfer(address(aToken), aDestination, aAmount)) {
+            uint256 tokenOutManaged = aToken == this.token0() ? token0Managed : token1Managed;
+            uint256 reserveOut = aToken == this.token0() ? aReserve0 : aReserve1;
+            if (reserveOut - tokenOutManaged < aAmount) {
+                assetManager.returnAsset(aToken == this.token0(), aAmount - (reserveOut - tokenOutManaged));
+                require(_safeTransfer(address(aToken), aDestination, aAmount), "RP: TRANSFER_FAILED");
+            } else {
+                revert("RP: TRANSFER_FAILED");
+            }
+        }
+    }
+
+    function _safeTransfer(address aToken, address aTo, uint256 aValue) internal returns (bool) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory data) = aToken.call(abi.encodeWithSelector(SELECTOR, aTo, aValue));
+        return success && (data.length == 0 || abi.decode(data, (bool)));
+    }
+
+    function mint(address aTo) external returns (uint256 rLiquidity) {
         // NB: Must sync management PNL before we load reserves.
         (uint256 lReserve0, uint256 lReserve1, uint32 lBlockTimestampLast,) = _lockAndLoad();
         (lReserve0, lReserve1) = _syncManaged(lReserve0, lReserve1);
@@ -85,7 +245,7 @@ contract StableMintBurn is StablePair {
         _managerCallback();
     }
 
-    function burn(address aTo) external override returns (uint256 rAmount0, uint256 rAmount1) {
+    function burn(address aTo) external returns (uint256 rAmount0, uint256 rAmount1) {
         // NB: Must sync management PNL before we load reserves.
         (uint256 lReserve0, uint256 lReserve1, uint32 lBlockTimestampLast,) = _lockAndLoad();
         (lReserve0, lReserve1) = _syncManaged(lReserve0, lReserve1);
@@ -112,13 +272,21 @@ contract StableMintBurn is StablePair {
         _managerCallback();
     }
 
-    function swap(int256, bool, address, bytes calldata) external pure override returns (uint256) {
+    function swap(int256, bool, address, bytes calldata) external pure returns (uint256) {
         revert("SMB: IMPOSSIBLE");
     }
 
     function _balances() internal view returns (uint256 rBalance0, uint256 rBalance1) {
         rBalance0 = this.token0().balanceOf(address(this)) + uint256(token0Managed);
-        rBalance1 = this.token0().balanceOf(address(this)) + uint256(token0Managed);
+        rBalance1 = this.token1().balanceOf(address(this)) + uint256(token1Managed);
+    }
+
+    function _totalToken0() internal view returns (uint256) {
+        return this.token0().balanceOf(address(this)) + uint256(token0Managed);
+    }
+
+    function _totalToken1() internal view returns (uint256) {
+        return this.token1().balanceOf(address(this)) + uint256(token1Managed);
     }
 
     function _mintFee(uint256 aReserve0, uint256 aReserve1) internal returns (uint256 rTotalSupply, uint256 rD) {
@@ -140,7 +308,7 @@ contract StableMintBurn is StablePair {
                     uint256 lPlatformShares = lNumerator / lDenominator;
 
                     if (lPlatformShares != 0) {
-                        address lPlatformFeeTo = factory.read(PLATFORM_FEE_TO_NAME).toAddress();
+                        address lPlatformFeeTo = this.factory().read(PLATFORM_FEE_TO_NAME).toAddress();
 
                         _mint(lPlatformFeeTo, lPlatformShares);
                         rTotalSupply += lPlatformShares;
@@ -149,6 +317,98 @@ contract StableMintBurn is StablePair {
             }
         } else if (lastInvariant != 0) {
             lastInvariant = 0;
+        }
+    }
+
+    function _getCurrentAPrecise() private view returns (uint64 rCurrentA) {
+        uint64 futureA = ampData.futureA;
+        uint64 futureATime = ampData.futureATime;
+
+        if (block.timestamp < futureATime) {
+            uint64 initialA = ampData.initialA;
+            uint64 initialATime = ampData.initialATime;
+            uint64 rampDuration = futureATime - initialATime;
+            uint64 rampElapsed = uint64(block.timestamp) - initialATime;
+
+            if (futureA > initialA) {
+                uint64 rampDelta = futureA - initialA;
+                rCurrentA = initialA + rampElapsed * rampDelta / rampDuration;
+            } else {
+                uint64 rampDelta = initialA - futureA;
+                rCurrentA = initialA - rampElapsed * rampDelta / rampDuration;
+            }
+        } else {
+            rCurrentA = futureA;
+        }
+    }
+
+    function _getNA() private view returns (uint256) {
+        return 2 * _getCurrentAPrecise();
+    }
+
+    function _computeLiquidity(uint256 aReserve0, uint256 aReserve1) private view returns (uint256 rLiquidity) {
+        unchecked {
+            uint256 adjustedReserve0 = aReserve0 * this.token0PrecisionMultiplier();
+            uint256 adjustedReserve1 = aReserve1 * this.token1PrecisionMultiplier();
+            rLiquidity = StableMath._computeLiquidityFromAdjustedBalances(adjustedReserve0, adjustedReserve1, _getNA());
+        }
+    }
+
+    function _splitSlot0Timestamp(uint32 aRawTimestamp) internal pure returns (uint32 rTimestamp, bool rLocked) {
+        rLocked = aRawTimestamp >> 31 == 1;
+        rTimestamp = aRawTimestamp & 0x7FFFFFFF;
+    }
+
+    function _updateOracle(uint256 aReserve0, uint256 aReserve1, uint32 aTimeElapsed, uint32 aTimestampLast)
+        internal
+    {
+        Observation storage previous = _observations[_slot0.index];
+
+        (uint256 currRawPrice, int112 currLogRawPrice) = StableOracleMath.calcLogPrice(
+            _getCurrentAPrecise(), aReserve0 * this.token0PrecisionMultiplier(), aReserve1 * this.token1PrecisionMultiplier()
+        );
+        // perf: see if we can avoid using prevClampedPrice and read the two previous oracle observations
+        // to figure out the previous clamped price
+        (uint256 currClampedPrice, int112 currLogClampedPrice) =
+        _calcClampedPrice(currRawPrice, prevClampedPrice, aTimeElapsed);
+        int112 currLogLiq = StableOracleMath.calcLogLiq(aReserve0, aReserve1);
+        prevClampedPrice = currClampedPrice;
+
+    unchecked {
+        int112 logAccRawPrice = previous.logAccRawPrice + currLogRawPrice * int112(int256(uint256(aTimeElapsed)));
+        int56 logAccClampedPrice =
+        previous.logAccClampedPrice + int56(currLogClampedPrice) * int56(int256(uint256(aTimeElapsed)));
+        int56 logAccLiq = previous.logAccLiquidity + int56(currLogLiq) * int56(int256(uint256(aTimeElapsed)));
+        _slot0.index += 1;
+        _observations[_slot0.index] = Observation(logAccRawPrice, logAccClampedPrice, logAccLiq, aTimestampLast);
+    }
+    }
+
+    function _currentTime() internal view returns (uint32) {
+        return uint32(block.timestamp % 2 ** 31);
+    }
+
+    function _calcClampedPrice(uint256 aCurrRawPrice, uint256 aPrevClampedPrice, uint256 aTimeElapsed)
+        internal
+        virtual
+        returns (uint256 rClampedPrice, int112 rClampedLogPrice)
+    {
+        if (aPrevClampedPrice == 0) {
+            return (aCurrRawPrice, int112(LogCompression.toLowResLog(aCurrRawPrice)));
+        }
+
+        if (stdMath.percentDelta(aCurrRawPrice, aPrevClampedPrice) > maxChangeRate * aTimeElapsed) {
+            // clamp the price
+            if (aCurrRawPrice > aPrevClampedPrice) {
+                rClampedPrice = aPrevClampedPrice * (1e18 + (maxChangeRate * aTimeElapsed)) / 1e18;
+            } else {
+                assert(aPrevClampedPrice > aCurrRawPrice);
+                rClampedPrice = aPrevClampedPrice * (1e18 - (maxChangeRate * aTimeElapsed)) / 1e18;
+            }
+            rClampedLogPrice = int112(LogCompression.toLowResLog(rClampedPrice));
+        } else {
+            rClampedPrice = aCurrRawPrice;
+            rClampedLogPrice = int112(LogCompression.toLowResLog(aCurrRawPrice));
         }
     }
 }

--- a/src/curve/stable/StableMintBurn.sol
+++ b/src/curve/stable/StableMintBurn.sol
@@ -38,7 +38,6 @@ contract StableMintBurn is ReservoirERC20, IAssetManagedPair {
     GenericFactory public immutable factory = GenericFactory(0x0000000000000000000000000000000000000000);
     ERC20 public immutable token0 = ERC20(0x0000000000000000000000000000000000000000);
     ERC20 public immutable token1 = ERC20(0x0000000000000000000000000000000000000000);
-
     uint128 public immutable token0PrecisionMultiplier = 0;
     uint128 public immutable token1PrecisionMultiplier = 0;
 

--- a/src/curve/stable/StableMintBurn.sol
+++ b/src/curve/stable/StableMintBurn.sol
@@ -19,7 +19,7 @@ import { ReservoirERC20, ERC20 } from "src/ReservoirERC20.sol";
 import { Slot0, Observation } from "src/ReservoirPair.sol";
 import { StablePair, AmplificationData } from "src/curve/stable/StablePair.sol";
 
-contract StableMintBurn is ReservoirERC20 {
+contract StableMintBurn is ReservoirERC20, IAssetManagedPair {
     using FactoryStoreLib for GenericFactory;
     using Bytes32Lib for bytes32;
     using SafeCast for uint256;
@@ -93,8 +93,8 @@ contract StableMintBurn is ReservoirERC20 {
             return (aReserve0, aReserve1);
         }
 
-        uint256 lToken0Managed = assetManager.getBalance(IAssetManagedPair(this), this.token0());
-        uint256 lToken1Managed = assetManager.getBalance(IAssetManagedPair(this), this.token1());
+        uint256 lToken0Managed = assetManager.getBalance(this, this.token0());
+        uint256 lToken1Managed = assetManager.getBalance(this, this.token1());
 
         rReserve0 = _handleReport(this.token0(), aReserve0, token0Managed, lToken0Managed);
         rReserve1 = _handleReport(this.token1(), aReserve1, token1Managed, lToken1Managed);
@@ -411,4 +411,8 @@ contract StableMintBurn is ReservoirERC20 {
             rClampedLogPrice = int112(LogCompression.toLowResLog(aCurrRawPrice));
         }
     }
+
+    function adjustManagement(int256 aToken0Change, int256 aToken1Change) external {}
+    function getReserves() public view returns (uint104 rReserve0, uint104 rReserve1, uint32 rBlockTimestampLast, uint16 rIndex) {}
+    function setManager(IAssetManager manager) external {}
 }

--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -99,7 +99,7 @@ contract StablePair is ReservoirPair {
     }
 
     // TODO: Should we use fallback?
-    function mint(address) external virtual override returns (uint256) {
+    function mint(address) external override returns (uint256) {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
@@ -122,7 +122,7 @@ contract StablePair is ReservoirPair {
     }
 
     // TODO: Should we use fallback?
-    function burn(address) external virtual override returns (uint256, uint256) {
+    function burn(address) external override returns (uint256, uint256) {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
@@ -146,7 +146,6 @@ contract StablePair is ReservoirPair {
 
     function swap(int256 aAmount, bool aInOrOut, address aTo, bytes calldata aData)
         external
-        virtual
         override
         returns (uint256 rAmountOut)
     {

--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -12,7 +12,6 @@ import { FactoryStoreLib } from "src/libraries/FactoryStore.sol";
 
 import { GenericFactory } from "src/GenericFactory.sol";
 import { ReservoirPair, Observation } from "src/ReservoirPair.sol";
-import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { StableMath } from "src/libraries/StableMath.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
 import { StableOracleMath } from "src/libraries/StableOracleMath.sol";
@@ -33,7 +32,7 @@ contract StablePair is ReservoirPair {
     using Bytes32Lib for bytes32;
 
     // solhint-disable-next-line var-name-mixedcase
-    address private immutable MINT_BURN_LOGIC;
+    address private immutable MINT_BURN_LOGIC = ConstantsLib.MINT_BURN_ADDRESS;
 
     string private constant PAIR_SWAP_FEE_NAME = "SP::swapFee";
     string private constant AMPLIFICATION_COEFFICIENT_NAME = "SP::amplificationCoefficient";
@@ -45,11 +44,10 @@ contract StablePair is ReservoirPair {
 
     // We need the 2 variables below to calculate the growth in liquidity between
     // minting and burning, for the purpose of calculating platformFee.
-    uint192 internal lastInvariant;
-    uint64 internal lastInvariantAmp;
+    uint192 private lastInvariant;
+    uint64 private lastInvariantAmp;
 
     constructor(address aToken0, address aToken1) ReservoirPair(aToken0, aToken1, PAIR_SWAP_FEE_NAME) {
-        MINT_BURN_LOGIC = ConstantsLib.getMintBurnAddress();
         ampData.initialA = factory.read(AMPLIFICATION_COEFFICIENT_NAME).toUint64() * uint64(StableMath.A_PRECISION);
         ampData.futureA = ampData.initialA;
         ampData.initialATime = uint64(block.timestamp);
@@ -212,7 +210,7 @@ contract StablePair is ReservoirPair {
     }
 
     function _getAmountOut(uint256 aAmountIn, uint256 aReserve0, uint256 aReserve1, bool aToken0In)
-        internal
+        private
         view
         returns (uint256)
     {
@@ -229,7 +227,7 @@ contract StablePair is ReservoirPair {
     }
 
     function _getAmountIn(uint256 aAmountOut, uint256 aReserve0, uint256 aReserve1, bool aToken0Out)
-        internal
+        private
         view
         returns (uint256)
     {
@@ -250,7 +248,7 @@ contract StablePair is ReservoirPair {
     /// @dev Originally
     /// https://github.com/saddle-finance/saddle-contract/blob/0b76f7fb519e34b878aa1d58cffc8d8dc0572c12/contracts/SwapUtils.sol#L319.
     /// @return rLiquidity The invariant, at the precision of the pool.
-    function _computeLiquidity(uint256 aReserve0, uint256 aReserve1) internal view returns (uint256 rLiquidity) {
+    function _computeLiquidity(uint256 aReserve0, uint256 aReserve1) private view returns (uint256 rLiquidity) {
         unchecked {
             uint256 adjustedReserve0 = aReserve0 * token0PrecisionMultiplier;
             uint256 adjustedReserve1 = aReserve1 * token1PrecisionMultiplier;
@@ -258,7 +256,7 @@ contract StablePair is ReservoirPair {
         }
     }
 
-    function _getCurrentAPrecise() internal view returns (uint64 rCurrentA) {
+    function _getCurrentAPrecise() private view returns (uint64 rCurrentA) {
         uint64 futureA = ampData.futureA;
         uint64 futureATime = ampData.futureATime;
 
@@ -281,7 +279,7 @@ contract StablePair is ReservoirPair {
     }
 
     /// @dev number of coins in the pool multiplied by A precise
-    function _getNA() internal view returns (uint256) {
+    function _getNA() private view returns (uint256) {
         return 2 * _getCurrentAPrecise();
     }
 

--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -43,12 +43,10 @@ contract StablePair is ReservoirPair {
 
     AmplificationData public ampData;
 
-    uint256 private _locked = 1;
-
     // We need the 2 variables below to calculate the growth in liquidity between
     // minting and burning, for the purpose of calculating platformFee.
-    uint192 private lastInvariant;
-    uint64 private lastInvariantAmp;
+    uint192 internal lastInvariant;
+    uint64 internal lastInvariantAmp;
 
     constructor(address aToken0, address aToken1) ReservoirPair(aToken0, aToken1, PAIR_SWAP_FEE_NAME) {
         MINT_BURN_LOGIC = ConstantsLib.getMintBurnAddress();
@@ -103,7 +101,7 @@ contract StablePair is ReservoirPair {
     }
 
     // TODO: Should we use fallback?
-    function mint(address) external override returns (uint256) {
+    function mint(address) external virtual override returns (uint256) {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
@@ -126,7 +124,7 @@ contract StablePair is ReservoirPair {
     }
 
     // TODO: Should we use fallback?
-    function burn(address) external override returns (uint256, uint256) {
+    function burn(address) external virtual override returns (uint256, uint256) {
         // DELEGATE TO StableMintBurn
         address lTarget = MINT_BURN_LOGIC;
 
@@ -150,6 +148,7 @@ contract StablePair is ReservoirPair {
 
     function swap(int256 aAmount, bool aInOrOut, address aTo, bytes calldata aData)
         external
+        virtual
         override
         returns (uint256 rAmountOut)
     {

--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -8,7 +8,6 @@ import { ERC20 } from "solmate/tokens/ERC20.sol";
 import { IReservoirCallee } from "src/interfaces/IReservoirCallee.sol";
 
 import { Bytes32Lib } from "src/libraries/Bytes32.sol";
-import { Create2Lib } from "src/libraries/Create2Lib.sol";
 import { FactoryStoreLib } from "src/libraries/FactoryStore.sol";
 
 import { GenericFactory } from "src/GenericFactory.sol";
@@ -52,9 +51,7 @@ contract StablePair is ReservoirPair {
     uint64 private lastInvariantAmp;
 
     constructor(address aToken0, address aToken1) ReservoirPair(aToken0, aToken1, PAIR_SWAP_FEE_NAME) {
-        MINT_BURN_LOGIC = factory.read("SP::STABLE_MINT_BURN").toAddress();
-        require(address(MINT_BURN_LOGIC).code.length > 0, "SP: MINT_BURN_NOT_DEPLOYED");
-
+        MINT_BURN_LOGIC = ConstantsLib.getMintBurnAddress();
         ampData.initialA = factory.read(AMPLIFICATION_COEFFICIENT_NAME).toUint64() * uint64(StableMath.A_PRECISION);
         ampData.futureA = ampData.initialA;
         ampData.initialATime = uint64(block.timestamp);

--- a/src/curve/stable/StablePair.sol
+++ b/src/curve/stable/StablePair.sol
@@ -48,6 +48,7 @@ contract StablePair is ReservoirPair {
     uint64 private lastInvariantAmp;
 
     constructor(address aToken0, address aToken1) ReservoirPair(aToken0, aToken1, PAIR_SWAP_FEE_NAME) {
+        require(MINT_BURN_LOGIC.code.length > 0, "SP: MINT_BURN_NOT_DEPLOYED") ;
         ampData.initialA = factory.read(AMPLIFICATION_COEFFICIENT_NAME).toUint64() * uint64(StableMath.A_PRECISION);
         ampData.futureA = ampData.initialA;
         ampData.initialATime = uint64(block.timestamp);

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -1,18 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import { Create2Lib } from "src/libraries/Create2Lib.sol";
-import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
-
-import "forge-std/console.sol";
-
 library ConstantsLib {
     // TODO: to replace this with the actual production address once the deployer address / key has been decided
-    // address public constant MINT_BURN_ADDRESS = 0xde10cb7b143e5637eaddfa55a9a41189d9810d0beb54480bcde2cd9af73bda02;
-
-    function getMintBurnAddress() external view returns (address) {
-        bytes memory lInitCode = bytes.concat(type(StableMintBurn).creationCode, abi.encode(0x2a9e8fa175F45b235efDdD97d2727741EF4Eee63), abi.encode(0x72384992222BE015DE0146a6D7E5dA0E19d2Ba49));
-        address lComputed = Create2Lib.computeAddress(msg.sender, lInitCode, 0);
-        return lComputed;
-    }
+    address public constant MINT_BURN_ADDRESS = 0x0000000000000000000000000000000000000000;
 }

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -1,8 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+import { Create2Lib } from "src/libraries/Create2Lib.sol";
 import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 
+import "forge-std/console.sol";
+
 library ConstantsLib {
-    bytes32 public constant MINT_BURN_KEY = bytes32(0xf629f8de34ecb99dffcf69ea812ed1fdbba96bee14757da972c41f5b986fc74d);
+    // TODO: to replace this with the actual production address once the deployer address / key has been decided
+    // address public constant MINT_BURN_ADDRESS = 0xde10cb7b143e5637eaddfa55a9a41189d9810d0beb54480bcde2cd9af73bda02;
+
+    function getMintBurnAddress() external view returns (address) {
+        bytes memory lInitCode = bytes.concat(type(StableMintBurn).creationCode, abi.encode(0x2a9e8fa175F45b235efDdD97d2727741EF4Eee63), abi.encode(0x72384992222BE015DE0146a6D7E5dA0E19d2Ba49));
+        address lComputed = Create2Lib.computeAddress(msg.sender, lInitCode, 0);
+        return lComputed;
+    }
 }

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -3,5 +3,5 @@ pragma solidity ^0.8.0;
 
 library ConstantsLib {
     // TODO: to replace this with the actual production address once the deployer address / key has been decided
-    address public constant MINT_BURN_ADDRESS = 0x0000000000000000000000000000000000000000;
+    address public constant MINT_BURN_ADDRESS = 0x3ae5c6B516E79A769a6B9CbEF4C8650079882e37;
 }

--- a/test/__fixtures/BaseTest.sol
+++ b/test/__fixtures/BaseTest.sol
@@ -8,7 +8,7 @@ import { GenericFactory } from "src/GenericFactory.sol";
 import { ReservoirPair } from "src/ReservoirPair.sol";
 import { ConstantProductPair } from "src/curve/constant-product/ConstantProductPair.sol";
 import { StablePair, AmplificationData } from "src/curve/stable/StablePair.sol";
-import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
+//import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
 import { FactoryStoreLib } from "src/libraries/FactoryStore.sol";
 import { OracleCaller } from "src/oracle/OracleCaller.sol";
@@ -43,19 +43,19 @@ abstract contract BaseTest is Test {
     OracleCaller internal _oracleCaller = new OracleCaller();
 
     constructor() {
-        try vm.envString("FOUNDRY_PROFILE") returns (string memory lProfile) {
-            if (keccak256(abi.encodePacked(lProfile)) == keccak256(abi.encodePacked("coverage"))) {
-                vm.writeFile(
-                    "scripts/unoptimized-stable-mint-burn-key",
-                    _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
-                );
-            }
-        } catch {
-            vm.writeFile(
-                "scripts/optimized-stable-mint-burn-key",
-                _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
-            );
-        }
+//        try vm.envString("FOUNDRY_PROFILE") returns (string memory lProfile) {
+//            if (keccak256(abi.encodePacked(lProfile)) == keccak256(abi.encodePacked("coverage"))) {
+//                vm.writeFile(
+//                    "scripts/unoptimized-stable-mint-burn-key",
+//                    _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
+//                );
+//            }
+//        } catch {
+//            vm.writeFile(
+//                "scripts/optimized-stable-mint-burn-key",
+//                _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
+//            );
+//        }
 
         // set shared variables
         _factory.write("Shared::platformFee", DEFAULT_PLATFORM_FEE);
@@ -72,7 +72,7 @@ abstract contract BaseTest is Test {
         _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 
-        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenA), address(_tokenB));
+//        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenA), address(_tokenB));
 
         // set oracle caller
         _factory.write("Shared::oracleCaller", address(_oracleCaller));

--- a/test/__fixtures/BaseTest.sol
+++ b/test/__fixtures/BaseTest.sol
@@ -43,20 +43,6 @@ abstract contract BaseTest is Test {
     OracleCaller internal _oracleCaller = new OracleCaller();
 
     constructor() {
-//        try vm.envString("FOUNDRY_PROFILE") returns (string memory lProfile) {
-//            if (keccak256(abi.encodePacked(lProfile)) == keccak256(abi.encodePacked("coverage"))) {
-//                vm.writeFile(
-//                    "scripts/unoptimized-stable-mint-burn-key",
-//                    _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
-//                );
-//            }
-//        } catch {
-//            vm.writeFile(
-//                "scripts/optimized-stable-mint-burn-key",
-//                _bytesToHex(abi.encodePacked(keccak256(type(StableMintBurn).creationCode)))
-//            );
-//        }
-
         // set shared variables
         _factory.write("Shared::platformFee", DEFAULT_PLATFORM_FEE);
         _factory.write("Shared::platformFeeTo", _platformFeeTo);

--- a/test/__fixtures/BaseTest.sol
+++ b/test/__fixtures/BaseTest.sol
@@ -72,10 +72,7 @@ abstract contract BaseTest is Test {
         _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 
-        _factory.addBytecode(type(StableMintBurn).creationCode);
-        address lStableMintBurn =
-            _factory.deploySharedContract(ConstantsLib.MINT_BURN_KEY, address(_tokenA), address(_tokenB));
-        _factory.write("SP::STABLE_MINT_BURN", lStableMintBurn);
+        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenA), address(_tokenB));
 
         // set oracle caller
         _factory.write("Shared::oracleCaller", address(_oracleCaller));

--- a/test/__fixtures/BaseTest.sol
+++ b/test/__fixtures/BaseTest.sol
@@ -58,8 +58,6 @@ abstract contract BaseTest is Test {
         _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 
-        _factory.deploySharedContract(type(StableMintBurn).creationCode);
-
         // set oracle caller
         _factory.write("Shared::oracleCaller", address(_oracleCaller));
         _oracleCaller.whitelistAddress(address(this), true);

--- a/test/__fixtures/BaseTest.sol
+++ b/test/__fixtures/BaseTest.sol
@@ -8,7 +8,7 @@ import { GenericFactory } from "src/GenericFactory.sol";
 import { ReservoirPair } from "src/ReservoirPair.sol";
 import { ConstantProductPair } from "src/curve/constant-product/ConstantProductPair.sol";
 import { StablePair, AmplificationData } from "src/curve/stable/StablePair.sol";
-//import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
+import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
 import { FactoryStoreLib } from "src/libraries/FactoryStore.sol";
 import { OracleCaller } from "src/oracle/OracleCaller.sol";
@@ -72,7 +72,7 @@ abstract contract BaseTest is Test {
         _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 
-//        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenA), address(_tokenB));
+        _factory.deploySharedContract(type(StableMintBurn).creationCode);
 
         // set oracle caller
         _factory.write("Shared::oracleCaller", address(_oracleCaller));

--- a/test/integration/Aave.t.sol
+++ b/test/integration/Aave.t.sol
@@ -80,12 +80,11 @@ contract AaveIntegrationTest is BaseTest {
 
         _factory = new GenericFactory(address(this));
         _factory.write("CP::swapFee", DEFAULT_SWAP_FEE_CP);
-        _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("Shared::platformFee", DEFAULT_PLATFORM_FEE);
         _factory.write("Shared::maxChangeRate", DEFAULT_MAX_CHANGE_RATE);
         _factory.addCurve(type(ConstantProductPair).creationCode);
-        _factory.deploySharedContract(type(StableMintBurn).creationCode);
         _factory.addCurve(type(StablePair).creationCode);
+        _factory.write("SP::swapFee", DEFAULT_SWAP_FEE_SP);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 
         _manager = new AaveManager(AAVE_POOL_ADDRESS_PROVIDER);

--- a/test/integration/Aave.t.sol
+++ b/test/integration/Aave.t.sol
@@ -84,7 +84,7 @@ contract AaveIntegrationTest is BaseTest {
         _factory.write("Shared::platformFee", DEFAULT_PLATFORM_FEE);
         _factory.write("Shared::maxChangeRate", DEFAULT_MAX_CHANGE_RATE);
         _factory.addCurve(type(ConstantProductPair).creationCode);
-//        _factory.addBytecode(type(StableMintBurn).creationCode);
+        _factory.deploySharedContract(type(StableMintBurn).creationCode);
         _factory.addCurve(type(StablePair).creationCode);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 

--- a/test/integration/Aave.t.sol
+++ b/test/integration/Aave.t.sol
@@ -84,7 +84,7 @@ contract AaveIntegrationTest is BaseTest {
         _factory.write("Shared::platformFee", DEFAULT_PLATFORM_FEE);
         _factory.write("Shared::maxChangeRate", DEFAULT_MAX_CHANGE_RATE);
         _factory.addCurve(type(ConstantProductPair).creationCode);
-        _factory.addBytecode(type(StableMintBurn).creationCode);
+//        _factory.addBytecode(type(StableMintBurn).creationCode);
         _factory.addCurve(type(StablePair).creationCode);
         _factory.write("SP::amplificationCoefficient", DEFAULT_AMP_COEFF);
 

--- a/test/unit/GenericFactory.t.sol
+++ b/test/unit/GenericFactory.t.sol
@@ -116,6 +116,6 @@ contract GenericFactoryTest is BaseTest {
 
         // act & assert
         vm.expectRevert("UNAUTHORIZED");
-        _factory.deploySharedContract(ConstantsLib.MINT_BURN_KEY, address(_tokenB), address(_tokenC));
+        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenB), address(_tokenC));
     }
 }

--- a/test/unit/GenericFactory.t.sol
+++ b/test/unit/GenericFactory.t.sol
@@ -115,7 +115,7 @@ contract GenericFactoryTest is BaseTest {
         vm.prank(_alice);
 
         // act & assert
-//        vm.expectRevert("UNAUTHORIZED");
-//        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenB), address(_tokenC));
+        vm.expectRevert("UNAUTHORIZED");
+        _factory.deploySharedContract(type(StableMintBurn).creationCode);
     }
 }

--- a/test/unit/GenericFactory.t.sol
+++ b/test/unit/GenericFactory.t.sol
@@ -115,7 +115,7 @@ contract GenericFactoryTest is BaseTest {
         vm.prank(_alice);
 
         // act & assert
-        vm.expectRevert("UNAUTHORIZED");
-        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenB), address(_tokenC));
+//        vm.expectRevert("UNAUTHORIZED");
+//        _factory.deploySharedContract(type(StableMintBurn).creationCode, address(_tokenB), address(_tokenC));
     }
 }

--- a/test/unit/GenericFactory.t.sol
+++ b/test/unit/GenericFactory.t.sol
@@ -107,15 +107,4 @@ contract GenericFactoryTest is BaseTest {
         assertEq(_factory.getPair(address(_tokenA), address(_tokenB), 0), address(_constantProductPair));
         assertEq(_factory.getPair(address(_tokenB), address(_tokenA), 0), address(_constantProductPair));
     }
-
-    function testDeploySharedContract() external { }
-
-    function testDeploySharedContract_OnlyOwner() external {
-        // assume
-        vm.prank(_alice);
-
-        // act & assert
-        vm.expectRevert("UNAUTHORIZED");
-        _factory.deploySharedContract(type(StableMintBurn).creationCode);
-    }
 }

--- a/test/unit/gas/GenericFactory.gas.sol
+++ b/test/unit/gas/GenericFactory.gas.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.0;
 import "test/__fixtures/BaseTest.sol";
 
 contract GenericFactoryGasTest is BaseTest {
+    function testCreateFactory() external {
+        new GenericFactory(address(this));
+    }
+
     function testCreateConstantProductPair() external {
         _factory.createPair(address(_tokenC), address(_tokenD), 0);
     }

--- a/test/unit/libraries/Constants.t.sol
+++ b/test/unit/libraries/Constants.t.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 
-import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
+//import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
 
 contract ConstantsLibTest is Test {

--- a/test/unit/libraries/Constants.t.sol
+++ b/test/unit/libraries/Constants.t.sol
@@ -8,6 +8,6 @@ import { ConstantsLib } from "src/libraries/Constants.sol";
 contract ConstantsLibTest is Test {
     function testMintBurnKey() public {
         // assert
-        assertEq(ConstantsLib.MINT_BURN_KEY, keccak256(type(StableMintBurn).creationCode));
+//        assertEq(ConstantsLib.MINT_BURN_KEY, keccak256(type(StableMintBurn).creationCode));
     }
 }

--- a/test/unit/libraries/Constants.t.sol
+++ b/test/unit/libraries/Constants.t.sol
@@ -2,12 +2,15 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 
-//import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
+import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
+import { Create2Lib } from "src/libraries/Create2Lib.sol";
 
 contract ConstantsLibTest is Test {
-    function testMintBurnKey() public {
+    function testMintBurnKey() external {
         // assert
-//        assertEq(ConstantsLib.MINT_BURN_KEY, keccak256(type(StableMintBurn).creationCode));
+        assertEq(
+            ConstantsLib.MINT_BURN_ADDRESS, Create2Lib.computeAddress(msg.sender, type(StableMintBurn).creationCode, 0)
+        );
     }
 }

--- a/test/unit/libraries/Constants.t.sol
+++ b/test/unit/libraries/Constants.t.sol
@@ -1,16 +1,16 @@
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import "test/__fixtures/BaseTest.sol";
 
 import { StableMintBurn } from "src/curve/stable/StableMintBurn.sol";
 import { ConstantsLib } from "src/libraries/Constants.sol";
-import { Create2Lib } from "src/libraries/Create2Lib.sol";
 
-contract ConstantsLibTest is Test {
+contract ConstantsLibTest is BaseTest {
     function testMintBurnKey() external {
         // assert
         assertEq(
-            ConstantsLib.MINT_BURN_ADDRESS, Create2Lib.computeAddress(msg.sender, type(StableMintBurn).creationCode, 0)
+            ConstantsLib.MINT_BURN_ADDRESS,
+            computeCreate2Address(0, keccak256(type(StableMintBurn).creationCode), address(_factory))
         );
     }
 }


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

- so if we make `StableMintBurn` inherit from `StablePair`, then it is not possible to hard code the `MINT_BURN_LOGIC` as a `constant` within `StablePair` itself, cuz it would be a circular loop. Right now it's using the dynamic calculation but that's too expensive in prod. So it seems that a read from the factory is still needed
- there is no way to avoid calling the constructor / providing valid token0/1 addresses to `StableMintBurn` is there? If that's the case, then we have to pass in a valid ERC20 token for it to call, else the constructor fails. 
   - one way to overcome this is to `CREATE2` two dummy tokens on each network, and then supply those as constructor arguments
   - perhaps the "cleanest" way to do it, is just to make `StableMintBurn` not inherit from anyone, but make it have the same storage layout as `StablePair`. That way, there is no need to call the constructor but at the same time allows us to `delegatecall`
- I've indeed verified using `forge inspect --pretty [StablePair | StableMintBurn] storage` that both contracts' storage layout is exactly the same 
- if only one copy of `StableMintBurn` is needed, then we don't need to add its bytecode, so I've removed it so we can just deploy straight up 