### PR TITLE
test: attempting to redeem while AAVE fully borrowed

### DIFF
--- a/src/interfaces/aave/IPool.sol
+++ b/src/interfaces/aave/IPool.sol
@@ -77,4 +77,22 @@ interface IPool {
      *
      */
     function withdraw(address asset, uint256 amount, address to) external returns (uint256);
+
+    /**
+     * @notice Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+     * already supplied enough collateral, or he was given enough allowance by a credit delegator on the
+     * corresponding debt token (StableDebtToken or VariableDebtToken)
+     * - E.g. User borrows 100 USDC passing as `onBehalfOf` his own address, receiving the 100 USDC in his wallet
+     *   and 100 stable/variable debt tokens, depending on the `interestRateMode`
+     * @param asset The address of the underlying asset to borrow
+     * @param amount The amount to be borrowed
+     * @param interestRateMode The interest rate mode at which the user wants to borrow: 1 for Stable, 2 for Variable
+     * @param referralCode The code used to register the integrator originating the operation, for potential rewards.
+     *   0 if the action is executed directly by the user, without any middle-man
+     * @param onBehalfOf The address of the user who will receive the debt. Should be the address of the borrower itself
+     * calling the function if he wants to borrow against his own collateral, or the address of the credit delegator
+     * if he has been given credit delegation allowance
+     */
+    function borrow(address asset, uint256 amount, uint256 interestRateMode, uint16 referralCode, address onBehalfOf)
+        external;
 }

--- a/src/interfaces/aave/IUiPoolDataProviderV3.sol
+++ b/src/interfaces/aave/IUiPoolDataProviderV3.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.10;
+
+import { IPoolAddressesProvider } from "./IPoolAddressesProvider.sol";
+
+interface IUiPoolDataProviderV3 {
+    struct InterestRates {
+        uint256 variableRateSlope1;
+        uint256 variableRateSlope2;
+        uint256 stableRateSlope1;
+        uint256 stableRateSlope2;
+        uint256 baseStableBorrowRate;
+        uint256 baseVariableBorrowRate;
+        uint256 optimalUsageRatio;
+    }
+
+    struct AggregatedReserveData {
+        address underlyingAsset;
+        string name;
+        string symbol;
+        uint256 decimals;
+        uint256 baseLTVasCollateral;
+        uint256 reserveLiquidationThreshold;
+        uint256 reserveLiquidationBonus;
+        uint256 reserveFactor;
+        bool usageAsCollateralEnabled;
+        bool borrowingEnabled;
+        bool stableBorrowRateEnabled;
+        bool isActive;
+        bool isFrozen;
+        // base data
+        uint128 liquidityIndex;
+        uint128 variableBorrowIndex;
+        uint128 liquidityRate;
+        uint128 variableBorrowRate;
+        uint128 stableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        address interestRateStrategyAddress;
+        //
+        uint256 availableLiquidity;
+        uint256 totalPrincipalStableDebt;
+        uint256 averageStableRate;
+        uint256 stableDebtLastUpdateTimestamp;
+        uint256 totalScaledVariableDebt;
+        uint256 priceInMarketReferenceCurrency;
+        address priceOracle;
+        uint256 variableRateSlope1;
+        uint256 variableRateSlope2;
+        uint256 stableRateSlope1;
+        uint256 stableRateSlope2;
+        uint256 baseStableBorrowRate;
+        uint256 baseVariableBorrowRate;
+        uint256 optimalUsageRatio;
+        // v3 only
+        bool isPaused;
+        bool isSiloedBorrowing;
+        uint128 accruedToTreasury;
+        uint128 unbacked;
+        uint128 isolationModeTotalDebt;
+        //
+        uint256 debtCeiling;
+        uint256 debtCeilingDecimals;
+        uint8 eModeCategoryId;
+        uint256 borrowCap;
+        uint256 supplyCap;
+        // eMode
+        uint16 eModeLtv;
+        uint16 eModeLiquidationThreshold;
+        uint16 eModeLiquidationBonus;
+        address eModePriceSource;
+        string eModeLabel;
+        bool borrowableInIsolation;
+    }
+
+    struct UserReserveData {
+        address underlyingAsset;
+        uint256 scaledATokenBalance;
+        bool usageAsCollateralEnabledOnUser;
+        uint256 stableBorrowRate;
+        uint256 scaledVariableDebt;
+        uint256 principalStableDebt;
+        uint256 stableBorrowLastUpdateTimestamp;
+    }
+
+    struct BaseCurrencyInfo {
+        uint256 marketReferenceCurrencyUnit;
+        int256 marketReferenceCurrencyPriceInUsd;
+        int256 networkBaseTokenPriceInUsd;
+        uint8 networkBaseTokenPriceDecimals;
+    }
+
+    function getReservesList(IPoolAddressesProvider provider) external view returns (address[] memory);
+
+    function getReservesData(IPoolAddressesProvider provider)
+        external
+        view
+        returns (AggregatedReserveData[] memory, BaseCurrencyInfo memory);
+
+    function getUserReservesData(IPoolAddressesProvider provider, address user)
+        external
+        view
+        returns (UserReserveData[] memory, uint8);
+}

--- a/test/integration/Aave.t.sol
+++ b/test/integration/Aave.t.sol
@@ -1148,7 +1148,7 @@ contract AaveIntegrationTest is BaseTest {
         // arrange
         _increaseManagementOneToken(10e6);
 
-        deal(address(WETH), _alice, lAmtWETHToDeal); // give alice 3000 WETH
+        deal(address(WETH), _alice, lAmtWETHToDeal);
         IPool lPool = _manager.pool();
         vm.startPrank(_alice);
         WETH.approve(address(lPool), type(uint256).max);


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- in this PR / issue I want to explore the scenario where AAVE's market is fully borrowed (utilization at 100%) and the pair tries to redeem, as mentioned by Michael from Euler previously

## Solution

- so this can occur when: 
   - some guy with a lot of collateral borrows the entire available liq
   - the pair receives a swap / burn request that demands more than its liq balance (30% as set by the manager) in the pair
- implications: 
  - our oracle cannot be updated if the swap or burn fails, resulting in inaccurate prices for as long as we cannot redeem
- mitigated by: 
  - attacker has to endure the sky high interest rates when borrowing the entirety of the liquidity
  - market will come provide liq when interest rates are so high

- given the conditions to make it happen and the ongoing costs, it seems that this attack is highly unlikely to be pulled off, and if did, would not be sustainable even for a few hours

- on hindsight I didn't even need to write a test case to show that the redemption would have failed, common sense would have sufficed 