### PR TITLE
feat: introduce guardian role asset manager

### DIFF
--- a/test/integration/Aave.t.sol
+++ b/test/integration/Aave.t.sol
@@ -244,7 +244,7 @@ contract AaveIntegrationTest is BaseTest {
         vm.assume(aAddress != address(this));
 
         // act & assert
-        vm.expectRevert("AM: UNAUTHORIZED");
+        vm.expectRevert("UNAUTHORIZED");
         _manager.setGuardian(_alice);
     }
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- decided to roll the previous `rewardSeller` into `guardian` since they are both trusted parties

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
