### PR TITLE
feat: introduce max change per trade

### DIFF
--- a/script/optimized-deployer-meta
+++ b/script/optimized-deployer-meta
@@ -1,6 +1,6 @@
 {
-  "constant_product_hash": "0x7b0f16c5cf2f4e78c4f697bfefb1365008f8865aaaa942f46ced4e0dea45c42a",
-  "factory_hash": "0xab6a26d7fb7b6df7e81d9f9354f8b767b5ac11b732f1b3f2e9d6e5b69a7d0754",
-  "oracle_caller_hash": "0x0d71d4a05b676bfbccd00e8422375c347a056fb93cc502cc962d5e6912213b04",
-  "stable_hash": "0xc5b9d3031f577510c547b9465241780111ad9d25a80dbe2292d1dc4290d9cd5a"
+  "constant_product_hash": "0x6bb54a3a2e0eef36a4ee1866eee21dc514fac57496141ce405f9af4e37f34941",
+  "factory_hash": "0x5d635090575f999ee44232af44309f6053dc93b7844bfdd90ee7a7919a4d363c",
+  "oracle_caller_hash": "0x529da7083c2ffd40e327dd40a4ae6f796de1561a0191b323d0cbfab827fab3b7",
+  "stable_hash": "0x51e93a48df3616a3e56c131684d126d7d3ddcd8911d5b807a773aca3a576439e"
 }

--- a/script/optimized-deployer-meta
+++ b/script/optimized-deployer-meta
@@ -1,6 +1,6 @@
 {
-  "constant_product_hash": "0x6bb54a3a2e0eef36a4ee1866eee21dc514fac57496141ce405f9af4e37f34941",
-  "factory_hash": "0x5d635090575f999ee44232af44309f6053dc93b7844bfdd90ee7a7919a4d363c",
-  "oracle_caller_hash": "0x529da7083c2ffd40e327dd40a4ae6f796de1561a0191b323d0cbfab827fab3b7",
-  "stable_hash": "0x51e93a48df3616a3e56c131684d126d7d3ddcd8911d5b807a773aca3a576439e"
+  "constant_product_hash": "0xbd78fb88c65e9a8804773c3a0e0350627ae244d6daf312a549fc1e08ef9bf56e",
+  "factory_hash": "0x84e232ec0f6ea2ec4c9e4cfa7e5469dab805cb65ffaab4a7ee9c7c602f91345a",
+  "oracle_caller_hash": "0xed0f7d96dcba353321d583022005b03c09088f7de3800703dc8324b1da6c77a6",
+  "stable_hash": "0x24174b50e2a4c46e25d5367496b6a2ca38bf33dceb07ef3aba32e2c1266a6bf1"
 }

--- a/src/Constants.sol
+++ b/src/Constants.sol
@@ -7,5 +7,6 @@ library Constants {
     uint256 public constant DEFAULT_SWAP_FEE_SP = 100; // 0.01%
     uint256 public constant DEFAULT_PLATFORM_FEE = 250_000; // 25%
     uint256 public constant DEFAULT_AMP_COEFF = 1000;
-    uint256 public constant DEFAULT_MAX_CHANGE_RATE = 0.0005e18;
+    uint128 public constant DEFAULT_MAX_CHANGE_RATE = 0.0005e18;
+    uint128 public constant DEFAULT_MAX_CHANGE_PER_TRADE = 0.03e18; // 3%
 }

--- a/src/ReservoirDeployer.sol
+++ b/src/ReservoirDeployer.sol
@@ -17,12 +17,12 @@ contract ReservoirDeployer {
     uint256 public step = 0;
 
     // Bytecode hashes.
-    bytes32 public constant FACTORY_HASH = bytes32(0x5d635090575f999ee44232af44309f6053dc93b7844bfdd90ee7a7919a4d363c);
+    bytes32 public constant FACTORY_HASH = bytes32(0x84e232ec0f6ea2ec4c9e4cfa7e5469dab805cb65ffaab4a7ee9c7c602f91345a);
     bytes32 public constant CONSTANT_PRODUCT_HASH =
-        bytes32(0x6bb54a3a2e0eef36a4ee1866eee21dc514fac57496141ce405f9af4e37f34941);
-    bytes32 public constant STABLE_HASH = bytes32(0x51e93a48df3616a3e56c131684d126d7d3ddcd8911d5b807a773aca3a576439e);
+        bytes32(0xbd78fb88c65e9a8804773c3a0e0350627ae244d6daf312a549fc1e08ef9bf56e);
+    bytes32 public constant STABLE_HASH = bytes32(0x24174b50e2a4c46e25d5367496b6a2ca38bf33dceb07ef3aba32e2c1266a6bf1);
     bytes32 public constant ORACLE_CALLER_HASH =
-        bytes32(0x529da7083c2ffd40e327dd40a4ae6f796de1561a0191b323d0cbfab827fab3b7);
+        bytes32(0xed0f7d96dcba353321d583022005b03c09088f7de3800703dc8324b1da6c77a6);
 
     // Deployment addresses.
     GenericFactory public factory;

--- a/src/ReservoirDeployer.sol
+++ b/src/ReservoirDeployer.sol
@@ -70,6 +70,7 @@ contract ReservoirDeployer {
         factory.write("Shared::platformFeeTo", address(this));
         factory.write("Shared::recoverer", address(this));
         factory.write("Shared::maxChangeRate", Constants.DEFAULT_MAX_CHANGE_RATE);
+        factory.write("Shared::maxChangePerTrade", Constants.DEFAULT_MAX_CHANGE_PER_TRADE);
 
         // Step complete.
         step += 1;

--- a/src/ReservoirDeployer.sol
+++ b/src/ReservoirDeployer.sol
@@ -17,12 +17,12 @@ contract ReservoirDeployer {
     uint256 public step = 0;
 
     // Bytecode hashes.
-    bytes32 public constant FACTORY_HASH = bytes32(0xab6a26d7fb7b6df7e81d9f9354f8b767b5ac11b732f1b3f2e9d6e5b69a7d0754);
+    bytes32 public constant FACTORY_HASH = bytes32(0x5d635090575f999ee44232af44309f6053dc93b7844bfdd90ee7a7919a4d363c);
     bytes32 public constant CONSTANT_PRODUCT_HASH =
-        bytes32(0x7b0f16c5cf2f4e78c4f697bfefb1365008f8865aaaa942f46ced4e0dea45c42a);
-    bytes32 public constant STABLE_HASH = bytes32(0xc5b9d3031f577510c547b9465241780111ad9d25a80dbe2292d1dc4290d9cd5a);
+        bytes32(0x6bb54a3a2e0eef36a4ee1866eee21dc514fac57496141ce405f9af4e37f34941);
+    bytes32 public constant STABLE_HASH = bytes32(0x51e93a48df3616a3e56c131684d126d7d3ddcd8911d5b807a773aca3a576439e);
     bytes32 public constant ORACLE_CALLER_HASH =
-        bytes32(0x0d71d4a05b676bfbccd00e8422375c347a056fb93cc502cc962d5e6912213b04);
+        bytes32(0x529da7083c2ffd40e327dd40a4ae6f796de1561a0191b323d0cbfab827fab3b7);
 
     // Deployment addresses.
     GenericFactory public factory;

--- a/src/ReservoirPair.sol
+++ b/src/ReservoirPair.sol
@@ -49,7 +49,7 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
             updateSwapFee();
             updatePlatformFee();
             updateOracleCaller();
-            setMaxChangeRate(factory.read(MAX_CHANGE_RATE_NAME).toUint256());
+            setClampParams(factory.read(MAX_CHANGE_RATE_NAME).toUint128(), factory.read(MAX_CHANGE_PER_TRADE_NAME).toUint128());
         }
     }
 
@@ -514,18 +514,21 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
     //////////////////////////////////////////////////////////////////////////*/
 
     event OracleCallerUpdated(address oldCaller, address newCaller);
-    event MaxChangeRateUpdated(uint256 oldMaxChangePerSecond, uint256 newMaxChangePerSecond);
+    event ClampParamsUpdated(uint128 newMaxChangeRatePerSecond, uint128 newMaxChangePerTrade);
 
     // 100 basis points per second which is 60% per minute
     uint256 internal constant MAX_CHANGE_PER_SEC = 0.01e18;
     string internal constant MAX_CHANGE_RATE_NAME = "Shared::maxChangeRate";
+    string internal constant MAX_CHANGE_PER_TRADE_NAME = "Shared::maxChangePerTrade";
     string internal constant ORACLE_CALLER_NAME = "Shared::oracleCaller";
 
     mapping(uint256 => Observation) internal _observations;
 
     // maximum allowed rate of change of price per second to mitigate oracle manipulation attacks in the face of
     // post-merge ETH. 1e18 == 100%
-    uint256 public maxChangeRate;
+    uint128 public maxChangeRate;
+    // how much the clamped price can move within one trade. 1e18 == 100%
+    uint128 public maxChangePerTrade;
 
     address public oracleCaller;
 
@@ -542,10 +545,12 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
         }
     }
 
-    function setMaxChangeRate(uint256 aMaxChangeRate) public onlyFactory {
+    function setClampParams(uint128 aMaxChangeRate, uint128 aMaxChangePerTrade) public onlyFactory {
         require(0 < aMaxChangeRate && aMaxChangeRate <= MAX_CHANGE_PER_SEC, "RP: INVALID_CHANGE_PER_SECOND");
-        emit MaxChangeRateUpdated(maxChangeRate, aMaxChangeRate);
+
+        emit ClampParamsUpdated(aMaxChangeRate, aMaxChangePerTrade);
         maxChangeRate = aMaxChangeRate;
+        maxChangePerTrade = aMaxChangePerTrade;
     }
 
     function _calcClampedPrice(
@@ -557,8 +562,14 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
     ) internal virtual returns (uint256 rClampedPrice, int256 rClampedLogPrice) {
         // call to `percentDelta` will revert if the difference between aCurrRawPrice and aPrevClampedPrice is
         // greater than uint196 (1e59). It is extremely unlikely that one trade can change the price by 1e59
-        // if aPreviousTimestamp is 0, this is the first calculation of clamped price, and so should be set to the raw price
-        if (aPreviousTimestamp == 0 || aCurrRawPrice.percentDelta(aPrevClampedPrice) <= maxChangeRate * aTimeElapsed) {
+        if (
+            (
+                aCurrRawPrice.percentDelta(aPrevClampedPrice) <= maxChangeRate * aTimeElapsed
+                    && aCurrRawPrice.percentDelta(aPrevClampedPrice) <= maxChangePerTrade
+            )
+            // this is the first ever calculation of clamped price, and so should be set to the raw price
+            || aPreviousTimestamp == 0
+        ) {
             (rClampedPrice, rClampedLogPrice) = (aCurrRawPrice, aCurrLogRawPrice);
         } else {
             // clamp the price

--- a/src/ReservoirPair.sol
+++ b/src/ReservoirPair.sol
@@ -580,11 +580,12 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
                 uint256 lRateLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 + maxChangeRate * aTimeElapsed, 1e18);
                 uint256 lPerTradeLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 + maxChangePerTrade, 1e18);
                 rClampedPrice = lRateLimitedPrice.min(lPerTradeLimitedPrice);
+                assert(rClampedPrice < aCurrRawPrice);
             } else {
-                assert(aPrevClampedPrice > aCurrRawPrice);
                 uint256 lRateLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 - maxChangeRate * aTimeElapsed, 1e18);
                 uint256 lPerTradeLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 - maxChangePerTrade , 1e18);
                 rClampedPrice = lRateLimitedPrice.max(lPerTradeLimitedPrice);
+                assert(rClampedPrice > aCurrRawPrice);
             }
             rClampedLogPrice = LogCompression.toLowResLog(rClampedPrice);
         }

--- a/src/ReservoirPair.sol
+++ b/src/ReservoirPair.sol
@@ -577,10 +577,14 @@ abstract contract ReservoirPair is IAssetManagedPair, ReservoirERC20 {
             // maxChangeRate <= 0.01e18 (50 bits)
             // aTimeElapsed <= 32 bits
             if (aCurrRawPrice > aPrevClampedPrice) {
-                rClampedPrice = aPrevClampedPrice.fullMulDiv(1e18 + maxChangeRate * aTimeElapsed, 1e18);
+                uint256 lRateLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 + maxChangeRate * aTimeElapsed, 1e18);
+                uint256 lPerTradeLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 + maxChangePerTrade, 1e18);
+                rClampedPrice = lRateLimitedPrice.min(lPerTradeLimitedPrice);
             } else {
                 assert(aPrevClampedPrice > aCurrRawPrice);
-                rClampedPrice = aPrevClampedPrice.fullMulDiv(1e18 - maxChangeRate * aTimeElapsed, 1e18);
+                uint256 lRateLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 - maxChangeRate * aTimeElapsed, 1e18);
+                uint256 lPerTradeLimitedPrice = aPrevClampedPrice.fullMulDiv(1e18 - maxChangePerTrade , 1e18);
+                rClampedPrice = lRateLimitedPrice.max(lPerTradeLimitedPrice);
             }
             rClampedLogPrice = LogCompression.toLowResLog(rClampedPrice);
         }

--- a/src/libraries/Bytes32.sol
+++ b/src/libraries/Bytes32.sol
@@ -26,6 +26,10 @@ library Bytes32Lib {
         return uint64(uint256(aValue));
     }
 
+    function toUint128(bytes32 aValue) internal pure returns (uint128) {
+        return uint128(uint256(aValue));
+    }
+
     function toUint256(bytes32 aValue) internal pure returns (uint256) {
         return uint256(aValue);
     }

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -448,7 +448,6 @@ contract OracleWriterTest is BaseTest {
     function testOracle_OverflowAccPrice(uint32 aNewStartTime) public randomizeStartTime(aNewStartTime) allPairs {
         // arrange - make the last observation close to overflowing
         (,,, uint16 lIndex) = _pair.getReserves();
-
         _writeObservation(_pair, lIndex, 1e3, 1e3, type(int88).max, type(int88).max, uint32(block.timestamp % 2 ** 31));
         Observation memory lPrevObs = _oracleCaller.observation(_pair, lIndex);
 

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -14,7 +14,7 @@ contract OracleWriterTest is BaseTest {
     using FactoryStoreLib for GenericFactory;
 
     event OracleCallerUpdated(address oldCaller, address newCaller);
-    event MaxChangeRateUpdated(uint256 oldMaxChangeRate, uint256 newMaxChangeRate);
+    event ClampParamsUpdated(uint256 oldMaxChangeRate, uint256 newMaxChangeRate);
 
     ReservoirPair[] internal _pairs;
     ReservoirPair internal _pair;
@@ -135,33 +135,33 @@ contract OracleWriterTest is BaseTest {
         assertEq(_pair.maxChangeRate(), Constants.DEFAULT_MAX_CHANGE_RATE);
     }
 
-    function testSetMaxChangeRate_OnlyFactory() external allPairs {
+    function testSetClampParams_OnlyFactory() external allPairs {
         // act & assert
         vm.expectRevert();
-        _pair.setMaxChangeRate(1);
+        _pair.setClampParams(1, 1);
 
         vm.prank(address(_factory));
         vm.expectEmit(false, false, false, true);
-        emit MaxChangeRateUpdated(Constants.DEFAULT_MAX_CHANGE_RATE, 1);
-        _pair.setMaxChangeRate(1);
+        emit ClampParamsUpdated(Constants.DEFAULT_MAX_CHANGE_RATE, 1);
+        _pair.setClampParams(1, 1);
         assertEq(_pair.maxChangeRate(), 1);
     }
 
-    function testSetMaxChangeRate_TooLow() external allPairs {
+    function testSetClampParams_TooLow() external allPairs {
         // act & assert
         vm.prank(address(_factory));
         vm.expectRevert("RP: INVALID_CHANGE_PER_SECOND");
-        _pair.setMaxChangeRate(0);
+        _pair.setClampParams(0, 0);
     }
 
-    function testSetMaxChangeRate_TooHigh(uint256 aMaxChangeRate) external allPairs {
+    function testSetClampParams_TooHigh(uint256 aMaxChangeRate) external allPairs {
         // assume
-        uint256 lMaxChangeRate = bound(aMaxChangeRate, 0.01e18 + 1, type(uint256).max);
+        uint128 lMaxChangeRate = uint128(bound(aMaxChangeRate, 0.01e18 + 1, type(uint128).max));
 
         // act & assert
         vm.prank(address(_factory));
         vm.expectRevert("RP: INVALID_CHANGE_PER_SECOND");
-        _pair.setMaxChangeRate(lMaxChangeRate);
+        _pair.setClampParams(lMaxChangeRate, 1);
     }
 
     function testOracle_NoWriteInSameTimestamp() public allPairs {

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -543,23 +543,24 @@ contract OracleWriterTest is BaseTest {
         // sanity - instant price is 3M
         (,,, uint16 lIndex) = lCP.getReserves();
         Observation memory lObs = _oracleCaller.observation(lCP, lIndex);
-        assertApproxEqRel(
-            LogCompression.fromLowResLog(lObs.logInstantClampedPrice),
-            3_000_000e18,
-            0.0001e18
-        );
+        assertApproxEqRel(LogCompression.fromLowResLog(lObs.logInstantClampedPrice), 3_000_000e18, 0.0001e18);
 
         // act - arbitrage happens that make the price go to around 3500 USD / ETH in one trade
         _stepTime(10);
         _tokenC.mint(address(lCP), 0.0000283e18);
-        lCP.swap(address(lCP.token0()) == address(_tokenC) ? int256(0.0000283e18) : -int256(0.0000283e18), true, address(this), "");
+        lCP.swap(
+            address(lCP.token0()) == address(_tokenC) ? int256(0.0000283e18) : -int256(0.0000283e18),
+            true,
+            address(this),
+            ""
+        );
 
         // the instant raw price now is at 3494 USD
         (,,, lIndex) = lCP.getReserves();
         lObs = _oracleCaller.observation(lCP, lIndex);
         assertApproxEqRel(LogCompression.fromLowResLog(lObs.logInstantRawPrice), 3494e18, 0.01e18);
         // but clamped price is at 2.98M
-        assertApproxEqRel(LogCompression.fromLowResLog(lObs.logInstantClampedPrice), 2984969e18, 0.01e18);
+        assertApproxEqRel(LogCompression.fromLowResLog(lObs.logInstantClampedPrice), 2_984_969e18, 0.01e18);
 
         uint256 lCounter;
         while (LogCompression.fromLowResLog(lObs.logInstantClampedPrice) > 3495e18) {

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -14,7 +14,7 @@ contract OracleWriterTest is BaseTest {
     using FactoryStoreLib for GenericFactory;
 
     event OracleCallerUpdated(address oldCaller, address newCaller);
-    event ClampParamsUpdated(uint256 oldMaxChangeRate, uint256 newMaxChangeRate);
+    event ClampParamsUpdated(uint128 newMaxChangeRatePerSecond, uint128 newMaxChangePerTrade);
 
     ReservoirPair[] internal _pairs;
     ReservoirPair internal _pair;
@@ -141,8 +141,8 @@ contract OracleWriterTest is BaseTest {
         _pair.setClampParams(1, 1);
 
         vm.prank(address(_factory));
-        vm.expectEmit(false, false, false, true);
-        emit ClampParamsUpdated(Constants.DEFAULT_MAX_CHANGE_RATE, 1);
+        vm.expectEmit(false, false, false, false);
+        emit ClampParamsUpdated(1, 1);
         _pair.setClampParams(1, 1);
         assertEq(_pair.maxChangeRate(), 1);
     }

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -315,7 +315,7 @@ contract OracleWriterTest is BaseTest {
             lOriginalPrice.fullMulDiv(1e18 - lMaxChangePerTrade, 1e18),
             0.0001e18
         );
-        assertLt(lObs.logInstantRawPrice, lObs.logInstantClampedPrice); // the raw price should be more negative than the clamped price
+        assertLt(lObs.logInstantRawPrice, lObs.logInstantClampedPrice); // the log of the raw price should be more negative than the log of the clamped price
     }
 
     function testUpdateOracle_DecreasePrice_ExceedMaxChangeRate() external allPairs { }

--- a/test/unit/OracleWriter.t.sol
+++ b/test/unit/OracleWriter.t.sol
@@ -414,28 +414,25 @@ contract OracleWriterTest is BaseTest {
     }
 
     function testOracle_OverflowAccPrice(uint32 aNewStartTime) public randomizeStartTime(aNewStartTime) allPairs {
-        // assume
-        vm.assume(aNewStartTime >= 1);
-
         // arrange - make the last observation close to overflowing
-        (,,, uint16 lIndex) = _stablePair.getReserves();
+        (,,, uint16 lIndex) = _pair.getReserves();
+
         _writeObservation(
-            _stablePair, lIndex, 1e3, 1e3, type(int88).max, type(int88).max, uint32(block.timestamp % 2 ** 31)
+            _pair, lIndex, 1e3, 1e3, type(int88).max, type(int88).max, uint32(block.timestamp % 2 ** 31)
         );
-        Observation memory lPrevObs = _oracleCaller.observation(_stablePair, lIndex);
+        Observation memory lPrevObs = _oracleCaller.observation(_pair, lIndex);
 
         // act
         uint256 lAmountToSwap = 5e18;
-        _tokenB.mint(address(_stablePair), lAmountToSwap);
-        _stablePair.swap(-int256(lAmountToSwap), true, address(this), "");
+        _tokenB.mint(address(_pair), lAmountToSwap);
+        _pair.swap(-int256(lAmountToSwap), true, address(this), "");
 
         _stepTime(5);
-        _stablePair.sync();
+        _pair.sync();
 
         // assert - when it overflows it goes from a very positive number to a very negative number
-        (,,, lIndex) = _stablePair.getReserves();
-        Observation memory lCurrObs = _oracleCaller.observation(_stablePair, lIndex);
+        (,,, lIndex) = _pair.getReserves();
+        Observation memory lCurrObs = _oracleCaller.observation(_pair, lIndex);
         assertLt(lCurrObs.logAccRawPrice, lPrevObs.logAccRawPrice);
     }
-
 }


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

with the implementation of this extra check (max change per trade), there are 4 possible scenarios: 

1. raw price doesn't violate both conditions
  - simple: clampedPrice = rawPrice 
2. raw price only violates rate of change, doesn't violate max change per trade
  - use the rate-of-change capped price  
  - is it possible that the max-change-per-trade capped price is a smaller change than rate-of-change-capped price? 
    - e.g. maxChangePerTrade is 2%, rate of change is 3bp/s. 
      - trade comes after 30 seconds, doing a 1% change in price. 
      - max-change-per-trade capped price is 102%, rate-of-change capped price is 100.9%
    - e.g. maxChangePerTrade is 2%, rate of change is 100bp/s. 
      - trade comes after 3 seconds, doing a 1% change in price
      - max-change-per-trade capped price is 102%, rate-of-change capped price is 103%
    - seems that it's not possible
3. raw price only violates max change per trade, doesn't violate rate of change
  - use the max-change-per-trade capped price 
4. raw violates both rate of change and max change per trade
  - should we take the rate-of-change capped or max-change-per-trade capped? 
  - should choose the closer one? Arithmetic / geometric mean of the two?
    - Arithmetic mean would be cheaper than geometric mean due to gas cost 
  - Propose to choose the closer one (smaller change)

